### PR TITLE
Added doc comments to field types and messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ to batch processing (see examples/streaming.rs).
 ## v0.2.0
 * Improve the API to allow manipulating the data with less cloning
 * Expose the actual MesgNum enum value to the user in the `kind` field
-of each FitDataRecord instead of it's name.
+of each FitDataRecord instead of its name.
 * Upated FitDataRecord to store fields as a Vec, sorted by definition
 number. Each field contains the name, number, value and units (if defined).
 * Rewrote parser logic to more closely resemble how serde deserializers are

--- a/build.rs
+++ b/build.rs
@@ -219,7 +219,7 @@ impl MessageDefinition {
                 return field;
             }
         }
-        panic!(format!("No field with name: {:?}", name));
+        panic!("No field with name: {:?}", name);
     }
 
     fn function_name(&self) -> String {
@@ -401,10 +401,7 @@ fn base_type_to_rust_type(base_type_str: &str) -> &'static str {
         "sint32" => "i32",
         "uint32" => "u32",
         "uint32z" => "u32",
-        _ => panic!(format!(
-            "unsupported base_type for enum field: {}",
-            base_type_str
-        )),
+        _ => panic!("unsupported base_type for enum field: {}", base_type_str),
     }
 }
 
@@ -504,13 +501,13 @@ fn process_types(sheet: Range<DataType>) -> Vec<FieldTypeDefintion> {
             // extract enum name
             let enum_name = match row[0].get_string() {
                 Some(v) => v.to_string(),
-                None => panic!(format!("Enum type name must be a string row={:?}.", row)),
+                None => panic!("Enum type name must be a string row={:?}.", row),
             };
 
             // extract base type and convert to it's rust equivalent
             let rust_type = match row[1].get_string() {
                 Some(v) => base_type_to_rust_type(v),
-                None => panic!(format!("Base type name must be a string row={:?}.", row)),
+                None => panic!("Base type name must be a string row={:?}.", row),
             };
             let comment = row[4].get_string().map(|v| v.to_string());
             field_types.push(FieldTypeDefintion::new(enum_name, rust_type, comment));
@@ -523,7 +520,7 @@ fn process_types(sheet: Range<DataType>) -> Vec<FieldTypeDefintion> {
             // extract enum name
             let name = match row[2].get_string() {
                 Some(v) => v.to_string(),
-                None => panic!(format!("Enum variant name must be a string row={:?}.", row)),
+                None => panic!("Enum variant name must be a string row={:?}.", row),
             };
 
             // handle mix of numeric and hex string data values
@@ -532,10 +529,7 @@ fn process_types(sheet: Range<DataType>) -> Vec<FieldTypeDefintion> {
                 DataType::Int(v) => *v,
                 DataType::String(v) => i64::from_str_radix(&v[2..], 16).unwrap(),
                 _ => {
-                    panic!(format!(
-                        "Unsupported enum variant value data type row={:?}.",
-                        row
-                    ));
+                    panic!("Unsupported enum variant value data type row={:?}.", row);
                 }
             };
             let comment = row[4].get_string().map(|v| v.to_string());

--- a/build.rs
+++ b/build.rs
@@ -504,7 +504,7 @@ fn process_types(sheet: Range<DataType>) -> Vec<FieldTypeDefintion> {
                 None => panic!("Enum type name must be a string row={:?}.", row),
             };
 
-            // extract base type and convert to it's rust equivalent
+            // extract base type and convert to its rust equivalent
             let rust_type = match row[1].get_string() {
                 Some(v) => base_type_to_rust_type(v),
                 None => panic!("Base type name must be a string row={:?}.", row),

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -85,9 +85,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         // shift remaining data to the front of buffer prior to appending more
         rem = buffer.len();
         let tmp = Vec::from(buffer);
-        for i in 0..rem {
-            data[i] = tmp[i];
-        }
+        data[..rem].clone_from_slice(&tmp[..rem]);
     }
 }
 

--- a/src/de/decode.rs
+++ b/src/de/decode.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Duration, Local, NaiveDate, TimeZone};
 use std::collections::HashMap;
 use std::convert::{From, TryInto};
 use std::f64::EPSILON;
-use std::iter::{FromIterator, IntoIterator};
+use std::iter::IntoIterator;
 
 impl Value {
     /// Convert the value into a vector of bytes
@@ -149,11 +149,10 @@ impl Decoder {
         // initialize process queue with field info for parsed, valid fields.
         let msg_num = mesg_info.global_message_number().as_u16();
         let mut data_fields = Vec::new();
-        let mut data_map: HashMap<u8, Value> = HashMap::from_iter(
-            data_map
-                .iter()
-                .filter_map(|(key, val)| val.as_ref().map(|v| (*key, v.clone()))),
-        );
+        let mut data_map: HashMap<u8, Value> = data_map
+            .iter()
+            .filter_map(|(key, val)| val.as_ref().map(|v| (*key, v.clone())))
+            .collect();
         let mut process_queue: Vec<(u8, Option<FieldInfo>)> = data_map
             .keys()
             .map(|k| (*k, get_message_field(&mesg_info, *k, &data_map).cloned()))
@@ -184,10 +183,8 @@ impl Decoder {
                         let dest_def_number = comp_info.dest_def_number();
                         let old_field_info =
                             get_message_field(&mesg_info, comp_info.dest_def_number(), &data_map);
-                        let new_field_info = match old_field_info {
-                            Some(info) => Some(comp_info.to_field_info(info)),
-                            None => None,
-                        };
+                        let new_field_info =
+                            old_field_info.map(|info| comp_info.to_field_info(info));
                         process_queue.push((dest_def_number, new_field_info));
                     }
                 }

--- a/src/de/parser.rs
+++ b/src/de/parser.rs
@@ -335,7 +335,7 @@ pub fn fit_message<'a>(
     match header.message_type {
         FitMessageType::Data => {
             if let Some(def_mesg) = definitions.get(&header.local_message_number) {
-                let (input, (fields, developer_fields)) = data_message_fields(input, &def_mesg)?;
+                let (input, (fields, developer_fields)) = data_message_fields(input, def_mesg)?;
                 Ok((
                     input,
                     FitMessage::Data(FitDataMessage {

--- a/src/de/parser.rs
+++ b/src/de/parser.rs
@@ -198,7 +198,7 @@ pub struct DeveloperFieldDefinition {
 
 /// Stores a vector of raw fields described by the preceding Definition message, a Definition message
 /// must come before any Data message. The data here will be transfomed into a FitDataRecord using
-/// the information from it's defintion message and the MessageInfo struct from the FIT profile
+/// the information from its defintion message and the MessageInfo struct from the FIT profile
 #[derive(Clone, Debug)]
 pub struct FitDataMessage {
     global_message_number: u16,
@@ -561,7 +561,7 @@ fn data_field_value(
             }
             BaseType::String => {
                 bytes_consumed += size;
-                // consume the field as defined by it's size and then locate the first NUL byte
+                // consume the field as defined by its size and then locate the first NUL byte
                 // and ignore everything after it when converting to a string
                 let (input, field_value) = take(size as usize)(input)?;
                 let mut value = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ impl convert::TryInto<i64> for Value {
     }
 }
 
-/// Describes a field value along with it's defined units (if any), this struct is useful for
+/// Describes a field value along with its defined units (if any), this struct is useful for
 /// serializing data in a key-value store where the key is either the name or definition number
 /// since it can be created from a `FitDataField` with minimal data cloning.
 #[derive(Clone, Debug, Serialize)]

--- a/src/profile/field_types.rs
+++ b/src/profile/field_types.rs
@@ -707,6 +707,7 @@ impl Serialize for MesgCount {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// seconds since UTC 00:00 Dec 31 1989
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum DateTime {
     /// if date_time is < 0x10000000 then it is system time (seconds from device power on)
@@ -753,6 +754,7 @@ impl Serialize for DateTime {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// seconds since 00:00 Dec 31 1989 in local time zone
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum LocalDateTime {
     /// if date_time is < 0x10000000 then it is system time (seconds from device power on)
@@ -1147,6 +1149,7 @@ impl Serialize for Language {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to language enum type (1 << language).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum LanguageBits0 {
     English,
@@ -2675,6 +2678,7 @@ impl Serialize for Sport {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to sport enum type (1 << sport).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits0 {
     Generic,
@@ -2749,6 +2753,7 @@ impl Serialize for SportBits0 {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to sport enum type (1 << (sport-8)).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits1 {
     Tennis,
@@ -2822,6 +2827,7 @@ impl Serialize for SportBits1 {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to sport enum type (1 << (sport-16)).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits2 {
     Mountaineering,
@@ -2895,6 +2901,7 @@ impl Serialize for SportBits2 {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to sport enum type (1 << (sport-24)).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits3 {
     Driving,
@@ -2968,6 +2975,7 @@ impl Serialize for SportBits3 {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to sport enum type (1 << (sport-32)).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits4 {
     Sailing,
@@ -3041,6 +3049,7 @@ impl Serialize for SportBits4 {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to sport enum type (1 << (sport-40)).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits5 {
     WaterSkiing,
@@ -3114,6 +3123,7 @@ impl Serialize for SportBits5 {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Bit field corresponding to sport enum type (1 << (sport-48)).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits6 {
     FloorClimbing,
@@ -4086,6 +4096,7 @@ impl Serialize for DateMode {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// Timeout in seconds.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum BacklightTimeout {
     /// Backlight stays on forever.
@@ -4439,6 +4450,7 @@ impl Serialize for EventType {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// timer event data
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum TimerTrigger {
     Manual,
@@ -4492,6 +4504,7 @@ impl Serialize for TimerTrigger {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// fitness equipment event data
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum FitnessEquipmentState {
     Ready,
@@ -8292,6 +8305,7 @@ impl Serialize for Weight {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// 0 - 100 indicates% of max hr; >100 indicates bpm (255 max) plus 100
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum WorkoutHr {
     BpmOffset,
@@ -8337,6 +8351,7 @@ impl Serialize for WorkoutHr {
         serializer.serialize_str(&self.to_string())
     }
 }
+/// 0 - 1000 indicates % of functional threshold power; >1000 indicates watts plus 1000.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum WorkoutPower {
     WattsOffset,

--- a/src/profile/field_types.rs
+++ b/src/profile/field_types.rs
@@ -1,4 +1,4 @@
-//! Auto generated profile field types from FIT SDK Release: 21.54.01
+//! Auto generated profile field types from FIT SDK Release: 21.60.00
 //! Not all of these may be used by the defined set of FIT messages
 #![allow(missing_docs)]
 #![allow(dead_code)]
@@ -3285,6 +3285,8 @@ pub enum SubSport {
     VirtualActivity,
     /// Used for events where participants run, crawl through mud, climb over walls, etc.
     Obstacle,
+    /// Sailing
+    SailRace,
     All,
     UnknownVariant(u8),
 }
@@ -3351,6 +3353,7 @@ impl SubSport {
             SubSport::ApneaHunting => 57,
             SubSport::VirtualActivity => 58,
             SubSport::Obstacle => 59,
+            SubSport::SailRace => 65,
             SubSport::All => 254,
             SubSport::UnknownVariant(value) => value,
         }
@@ -3422,6 +3425,7 @@ impl fmt::Display for SubSport {
             SubSport::ApneaHunting => write!(f, "apnea_hunting"),
             SubSport::VirtualActivity => write!(f, "virtual_activity"),
             SubSport::Obstacle => write!(f, "obstacle"),
+            SubSport::SailRace => write!(f, "sail_race"),
             SubSport::All => write!(f, "all"),
             SubSport::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
         }
@@ -3490,6 +3494,7 @@ impl convert::From<u8> for SubSport {
             57 => SubSport::ApneaHunting,
             58 => SubSport::VirtualActivity,
             59 => SubSport::Obstacle,
+            65 => SubSport::SailRace,
             254 => SubSport::All,
             _ => SubSport::UnknownVariant(value),
         }
@@ -6628,6 +6633,7 @@ pub enum GarminProduct {
     LegacyFirstAvengerAsia,
     LegacyReyAsia,
     LegacyDarthVaderAsia,
+    DescentMk2s,
     Edge130Plus,
     Edge1030Plus,
     /// Rally 100/200 Power Meter Series
@@ -6654,6 +6660,7 @@ pub enum GarminProduct {
     VenusqAsia,
     MarqGolferAsia,
     EnduroAsia,
+    DescentMk2sAsia,
     ApproachS42,
     Venu2sAsia,
     Venu2Asia,
@@ -6984,6 +6991,7 @@ impl GarminProduct {
             GarminProduct::LegacyFirstAvengerAsia => 3536,
             GarminProduct::LegacyReyAsia => 3537,
             GarminProduct::LegacyDarthVaderAsia => 3538,
+            GarminProduct::DescentMk2s => 3542,
             GarminProduct::Edge130Plus => 3558,
             GarminProduct::Edge1030Plus => 3570,
             GarminProduct::Rally200 => 3578,
@@ -7008,6 +7016,7 @@ impl GarminProduct {
             GarminProduct::VenusqAsia => 3837,
             GarminProduct::MarqGolferAsia => 3850,
             GarminProduct::EnduroAsia => 3872,
+            GarminProduct::DescentMk2sAsia => 3930,
             GarminProduct::ApproachS42 => 3934,
             GarminProduct::Venu2sAsia => 3949,
             GarminProduct::Venu2Asia => 3950,
@@ -7347,6 +7356,7 @@ impl fmt::Display for GarminProduct {
             GarminProduct::LegacyFirstAvengerAsia => write!(f, "legacy_first_avenger_asia"),
             GarminProduct::LegacyReyAsia => write!(f, "legacy_rey_asia"),
             GarminProduct::LegacyDarthVaderAsia => write!(f, "legacy_darth_vader_asia"),
+            GarminProduct::DescentMk2s => write!(f, "descent_mk2s"),
             GarminProduct::Edge130Plus => write!(f, "edge_130_plus"),
             GarminProduct::Edge1030Plus => write!(f, "edge_1030_plus"),
             GarminProduct::Rally200 => write!(f, "rally_200"),
@@ -7371,6 +7381,7 @@ impl fmt::Display for GarminProduct {
             GarminProduct::VenusqAsia => write!(f, "venusq_asia"),
             GarminProduct::MarqGolferAsia => write!(f, "marq_golfer_asia"),
             GarminProduct::EnduroAsia => write!(f, "enduro_asia"),
+            GarminProduct::DescentMk2sAsia => write!(f, "descent_mk2s_asia"),
             GarminProduct::ApproachS42 => write!(f, "approach_s42"),
             GarminProduct::Venu2sAsia => write!(f, "venu2s_asia"),
             GarminProduct::Venu2Asia => write!(f, "venu2_asia"),
@@ -7701,6 +7712,7 @@ impl convert::From<u16> for GarminProduct {
             3536 => GarminProduct::LegacyFirstAvengerAsia,
             3537 => GarminProduct::LegacyReyAsia,
             3538 => GarminProduct::LegacyDarthVaderAsia,
+            3542 => GarminProduct::DescentMk2s,
             3558 => GarminProduct::Edge130Plus,
             3570 => GarminProduct::Edge1030Plus,
             3578 => GarminProduct::Rally200,
@@ -7725,6 +7737,7 @@ impl convert::From<u16> for GarminProduct {
             3837 => GarminProduct::VenusqAsia,
             3850 => GarminProduct::MarqGolferAsia,
             3872 => GarminProduct::EnduroAsia,
+            3930 => GarminProduct::DescentMk2sAsia,
             3934 => GarminProduct::ApproachS42,
             3949 => GarminProduct::Venu2sAsia,
             3950 => GarminProduct::Venu2Asia,

--- a/src/profile/messages.rs
+++ b/src/profile/messages.rs
@@ -1,11 +1,11 @@
-//! Auto generated profile messages from FIT SDK Release: 21.54.01
+//! Auto generated profile messages from FIT SDK Release: 21.60.00
 #![allow(missing_docs)]
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::unreadable_literal)]
 use super::field_types::*;
 use super::{ComponentFieldInfo, FieldDataType, FieldInfo, MessageInfo};
 use std::collections::HashMap;
-pub const VERSION: &str = "21.54.01";
+pub const VERSION: &str = "21.60.00";
 pub fn file_id_message() -> MessageInfo {
     let mut fields = HashMap::new();
     let field = FieldInfo {

--- a/src/profile/messages.rs
+++ b/src/profile/messages.rs
@@ -6,6 +6,7 @@ use super::field_types::*;
 use super::{ComponentFieldInfo, FieldDataType, FieldInfo, MessageInfo};
 use std::collections::HashMap;
 pub const VERSION: &str = "21.60.00";
+/// Must be first message in file.
 pub fn file_id_message() -> MessageInfo {
     let mut fields = HashMap::new();
     let field = FieldInfo {
@@ -8780,6 +8781,7 @@ pub fn device_info_message() -> MessageInfo {
         fields,
     }
 }
+/// Corresponds to file_id of workout or course.
 pub fn training_file_message() -> MessageInfo {
     let mut fields = HashMap::new();
     let field = FieldInfo {
@@ -8921,6 +8923,7 @@ pub fn training_file_message() -> MessageInfo {
         fields,
     }
 }
+/// Heart rate variability
 pub fn hrv_message() -> MessageInfo {
     let mut fields = HashMap::new();
     // Time between beats
@@ -11179,6 +11182,7 @@ pub fn course_point_message() -> MessageInfo {
         fields,
     }
 }
+/// Unique Identification data for a segment file
 pub fn segment_id_message() -> MessageInfo {
     let mut fields = HashMap::new();
     // Friendly name assigned to segment
@@ -11304,6 +11308,7 @@ pub fn segment_id_message() -> MessageInfo {
         fields,
     }
 }
+/// Unique Identification data for an individual segment leader within a segment file
 pub fn segment_leaderboard_entry_message() -> MessageInfo {
     let mut fields = HashMap::new();
     // Friendly name assigned to leader
@@ -11402,6 +11407,7 @@ pub fn segment_leaderboard_entry_message() -> MessageInfo {
         fields,
     }
 }
+/// Navigation and race evaluation point for a segment decribing a point along the segment path and time it took each segment leader to reach that point
 pub fn segment_point_message() -> MessageInfo {
     let mut fields = HashMap::new();
     let field = FieldInfo {
@@ -12642,6 +12648,7 @@ pub fn segment_lap_message() -> MessageInfo {
         fields,
     }
 }
+/// Summary of the unique segment and leaderboard information associated with a segment file. This message is used to compile a segment list file describing all segment files on a device. The segment list file is used when refreshing the contents of a segment file with the latest available leaderboard information.
 pub fn segment_file_message() -> MessageInfo {
     let mut fields = HashMap::new();
     // UUID of the segment file
@@ -14986,6 +14993,7 @@ pub fn hr_message() -> MessageInfo {
         fields,
     }
 }
+/// Value from 1 to 100 calculated by FirstBeat
 pub fn stress_level_message() -> MessageInfo {
     let mut fields = HashMap::new();
     let field = FieldInfo {
@@ -15786,6 +15794,7 @@ pub fn exd_data_concept_configuration_message() -> MessageInfo {
         fields,
     }
 }
+/// Must be logged before developer field is used
 pub fn field_description_message() -> MessageInfo {
     let mut fields = HashMap::new();
     let field = FieldInfo {
@@ -15962,6 +15971,7 @@ pub fn field_description_message() -> MessageInfo {
         fields,
     }
 }
+/// Must be logged before field description
 pub fn developer_data_id_message() -> MessageInfo {
     let mut fields = HashMap::new();
     let field = FieldInfo {


### PR DESCRIPTION
Example: `DateTime` now has the comment `/// seconds since UTC 00:00 Dec 31 1989` from the `Profile.xlsx`.

This PR also includes:

- Clippy fixes
- Typo fixes
- Bump to version 21.60.00