### PR TITLE
Make crc check optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Bump packaged FIT SDK version to 21.60.00 (by xehpuk)
 * Clippy/Typo cleanup (by danielalvsaaker, xehpuk)
 * Add doc comments to field types and messages (by xehpuk)
+* Allow CRC validation to be skipped.
 
 ## v0.4.2
 * Bump packaged FIT SDK version to 21.54.01

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -267,7 +267,7 @@ pub fn from_bytes(mut buffer: &[u8]) -> Result<Vec<FitDataRecord>> {
 /// Deserialize a FIT file stored in a source that implements io::Read, with additional decode options
 pub fn from_reader_with_options<T: Read>(
     source: &mut T,
-    options: HashSet<DecodeOption>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataRecord>> {
     let mut buffer = Vec::new();
     source.read_to_end(&mut buffer)?;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -276,7 +276,5 @@ pub fn from_reader_with_options<T: Read>(
 
 /// Deserialize a FIT file stored in a source that implements io::Read.
 pub fn from_reader<T: Read>(source: &mut T) -> Result<Vec<FitDataRecord>> {
-    let mut buffer = Vec::new();
-    source.read_to_end(&mut buffer)?;
-    from_bytes_with_options(&buffer, &HashSet::new())
+    from_reader_with_options(source, &HashSet::new())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! that parses FIT files and exports them as JSON.
 //! ```
 //! use fitparser;
+//! use fitparser::de::{DecodeOption, from_reader_with_options};
 //! use std::fs::File;
 //! use std::io::prelude::*;
 //!
@@ -21,6 +22,16 @@
 //!     // print the data in FIT file
 //!     println!("{:#?}", data);
 //! }
+//!
+//! // Optionally ignore CRC validation
+//! let opts = [DecodeOption::SkipHeaderCrcValidation,
+//!             DecodeOption::SkipDataCrcValidation].iter().map(|o| *o).collect();
+//! let mut fp = File::open("tests/fixtures/Activity.fit")?;
+//! for data in from_reader_with_options(&mut fp, &opts)? {
+//!     // print the data in FIT file
+//!     println!("{:#?}", data);
+//! }
+//!
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 #![warn(missing_docs)]


### PR DESCRIPTION
Allows one to skip header and data CRCs as desired.

Fixes #3, Closes #4 