### PR TITLE
Handle zero fit header crc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Clippy/Typo cleanup (by danielalvsaaker, xehpuk)
 * Add doc comments to field types and messages (by xehpuk)
 * Allow CRC validation to be skipped.
+* Properly handle FIT files where the header CRC is zero (credit ddboline)
 
 ## v0.4.2
 * Bump packaged FIT SDK version to 21.54.01


### PR DESCRIPTION
Properly parse FIT files with a header CRC value of 0. This wasn't clear in the protocol documentation but when the header CRC is equal to 0 we treat it as if i doesn't exist and all bytes are used to compute the end of file CRC.

@ddboline thank you for bringing this to my attention. I didn't realize what your initial PR was trying to address, let me know if this implementation meets your needs.