### PR TITLE
Add additional decode options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Restructured project to drop the calamine dependency for end users, profile
   generation is now done in a separate private crate
 * Update calamine dependency
+* Refactor profile decoding module to be functional and not create large "info" structures
+* Implement new decoding options to cover additional use cases
 
 ## v0.5.1
 * Bump packaged FIT SDK version to 21.89.00

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ a streaming data source you can use the `de::FitStreamProcessor` struct. See
 the `streaming.rs` example file for basic usage and manual processing of
 `FitObject` variants.
 
+Additional decoding options are also available to customize the output of the
+parser. See the source code of the `fitparser/src/de/mod.rs` to view all options
+(or view the crate docs). The `fit_to_json` example program demos all of the
+currently available options as well.
+
 
 ## Updating the FIT profile
 

--- a/fitparser/examples/fit_to_json.rs
+++ b/fitparser/examples/fit_to_json.rs
@@ -34,6 +34,10 @@ struct Cli {
     #[structopt(long)]
     numeric_enums: bool,
 
+    /// Keep generic subfield names in the output instead of the specific resolved name
+    #[structopt(long)]
+    keep_generic_names: bool,
+
     /// Skip checking the header and data section CRC values
     #[structopt(long)]
     no_crc_check: bool,
@@ -115,6 +119,9 @@ fn run() -> Result<(), Box<dyn Error>> {
     if opt.drop_unknown {
         decode_opts.insert(DecodeOption::DropUnknownFields);
         decode_opts.insert(DecodeOption::DropUnknownMessages);
+    }
+    if opt.keep_generic_names {
+        decode_opts.insert(DecodeOption::UseGenericSubFieldName);
     }
     if opt.numeric_enums {
         decode_opts.insert(DecodeOption::ReturnNumericEnumValues);

--- a/fitparser/examples/fit_to_json.rs
+++ b/fitparser/examples/fit_to_json.rs
@@ -26,6 +26,10 @@ struct Cli {
     #[structopt(short, long, parse(from_os_str))]
     output: Option<PathBuf>,
 
+    /// Drop fields and messages that aren't defined in the profile
+    #[structopt(long)]
+    drop_unknown: bool,
+
     /// Return all enum values with their numeric value instead of the string variant name
     #[structopt(long)]
     numeric_enums: bool,
@@ -108,6 +112,9 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     // set any decode options
     let mut decode_opts = HashSet::new();
+    if opt.drop_unknown {
+        decode_opts.insert(DecodeOption::DropUnknownFields);
+    }
     if opt.numeric_enums {
         decode_opts.insert(DecodeOption::ReturnNumericEnumValues);
     }

--- a/fitparser/examples/fit_to_json.rs
+++ b/fitparser/examples/fit_to_json.rs
@@ -114,6 +114,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut decode_opts = HashSet::new();
     if opt.drop_unknown {
         decode_opts.insert(DecodeOption::DropUnknownFields);
+        decode_opts.insert(DecodeOption::DropUnknownMessages);
     }
     if opt.numeric_enums {
         decode_opts.insert(DecodeOption::ReturnNumericEnumValues);

--- a/fitparser/src/de/mod.rs
+++ b/fitparser/src/de/mod.rs
@@ -28,6 +28,8 @@ pub enum DecodeOption {
     SkipHeaderCrcValidation,
     /// Ignore data section checksum value
     SkipDataCrcValidation,
+    /// Keep the generic name when resolving subfields in the FIT profile
+    UseGenericSubFieldName,
 }
 
 /// Stores a FIT file object (header, message or CRC)

--- a/fitparser/src/de/mod.rs
+++ b/fitparser/src/de/mod.rs
@@ -17,12 +17,16 @@ pub use parser::{FitDataMessage, FitDefinitionMessage, FitFileHeader};
 /// Decoding options for the deserializer
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum DecodeOption {
+    /// Drop message fields that don't exist in the generated profile
+    DropUnknownFields,
+    /// Drop entire messages that don't exist in the generated profile
+    DropUnknownMessages,
+    /// Return the numeric value instead of string name for all enums
+    ReturnNumericEnumValues,
     /// Ignore header section checksum value if it exists
     SkipHeaderCrcValidation,
     /// Ignore data section checksum value
     SkipDataCrcValidation,
-    /// Return the numeric value instead of string name for all enums
-    ReturnNumericEnumValues,
 }
 
 /// Stores a FIT file object (header, message or CRC)
@@ -262,7 +266,10 @@ pub fn from_bytes_with_options(
         match obj {
             FitObject::Crc(..) => processor.reset(),
             FitObject::Header(..) => {}
-            FitObject::DataMessage(msg) => records.push(processor.decode_message(msg)?),
+            FitObject::DataMessage(msg) => {
+                // add code to drop unknown messages
+                records.push(processor.decode_message(msg)?)
+            }
             FitObject::DefinitionMessage(..) => {}
         }
         buffer = buf;

--- a/fitparser/src/de/mod.rs
+++ b/fitparser/src/de/mod.rs
@@ -21,6 +21,8 @@ pub enum DecodeOption {
     SkipHeaderCrcValidation,
     /// Ignore data section checksum value
     SkipDataCrcValidation,
+    /// Return the numeric value instead of string name for all enums
+    ReturnNumericEnumValues,
 }
 
 /// Stores a FIT file object (header, message or CRC)
@@ -63,6 +65,11 @@ impl Deserializer {
             end_of_messages: 0,
             crc: 0,
         }
+    }
+
+    /// Fetch options for the deserializer
+    fn options(&mut self) -> &HashSet<DecodeOption> {
+        &self.options
     }
 
     /// Add or remove decoding options for deserializer by manipulating the set
@@ -235,7 +242,8 @@ impl FitStreamProcessor {
 
     /// Decode a FIT data message into a FIT data record using the defined FIT profile.
     pub fn decode_message(&mut self, msg: FitDataMessage) -> Result<FitDataRecord> {
-        self.decoder.decode_message(msg)
+        self.decoder
+            .decode_message(msg, self.deserializer.options())
     }
 }
 

--- a/fitparser/src/profile/decode.rs
+++ b/fitparser/src/profile/decode.rs
@@ -207,7 +207,11 @@ fn file_id_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -492,7 +496,11 @@ fn file_creator_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -662,7 +670,11 @@ fn timestamp_correlation_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -906,7 +918,11 @@ fn software_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -1121,7 +1137,11 @@ fn slave_device_message(
                     )?);
                 }
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -1299,7 +1319,11 @@ fn capabilities_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -1501,7 +1525,11 @@ fn file_capabilities_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -1800,7 +1828,11 @@ fn mesg_capabilities_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -2097,7 +2129,11 @@ fn field_capabilities_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -2585,7 +2621,11 @@ fn device_settings_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -3630,7 +3670,11 @@ fn user_profile_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -4494,7 +4538,11 @@ fn hrm_profile_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -4751,7 +4799,11 @@ fn sdm_profile_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -5404,7 +5456,11 @@ fn bike_profile_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -6456,7 +6512,11 @@ fn connectivity_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -6900,7 +6960,11 @@ fn watchface_settings_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -7077,7 +7141,11 @@ fn ohr_settings_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -7212,7 +7280,11 @@ fn zones_target_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -7402,7 +7474,11 @@ fn sport_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -7538,7 +7614,11 @@ fn hr_zone_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -7674,7 +7754,11 @@ fn speed_zone_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -7810,7 +7894,11 @@ fn cadence_zone_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -7946,7 +8034,11 @@ fn power_zone_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -8095,7 +8187,11 @@ fn met_zone_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -8548,7 +8644,11 @@ fn dive_settings_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -9310,7 +9410,11 @@ fn dive_alarm_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -9567,7 +9671,11 @@ fn dive_gas_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -9860,7 +9968,11 @@ fn goal_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -10333,7 +10445,11 @@ fn activity_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -12483,7 +12599,11 @@ fn session_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -17722,7 +17842,11 @@ fn lap_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -21079,7 +21203,11 @@ fn length_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -22599,7 +22727,11 @@ fn record_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -25508,7 +25640,11 @@ fn event_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -26904,7 +27040,11 @@ fn device_info_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -27606,7 +27746,11 @@ fn device_aux_battery_info_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -27928,7 +28072,11 @@ fn training_file_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -28374,7 +28522,11 @@ fn weather_conditions_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -28905,7 +29057,11 @@ fn weather_alert_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -29204,7 +29360,11 @@ fn gps_metadata_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -29530,7 +29690,11 @@ fn camera_event_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -29807,7 +29971,11 @@ fn gyroscope_data_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -30240,7 +30408,11 @@ fn accelerometer_data_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -30706,7 +30878,11 @@ fn magnetometer_data_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -31021,7 +31197,11 @@ fn barometer_data_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -31283,7 +31463,11 @@ fn three_d_sensor_calibration_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -31646,7 +31830,11 @@ fn one_d_sensor_calibration_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -31893,7 +32081,11 @@ fn video_frame_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -32116,7 +32308,11 @@ fn obdii_data_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -32417,7 +32613,11 @@ fn nmea_sentence_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -32680,7 +32880,11 @@ fn aviation_attitude_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -33060,7 +33264,11 @@ fn video_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -33198,7 +33406,11 @@ fn video_title_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -33336,7 +33548,11 @@ fn video_description_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -33526,7 +33742,11 @@ fn video_clip_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -33879,7 +34099,11 @@ fn set_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -34326,7 +34550,11 @@ fn jump_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -34676,7 +34904,11 @@ fn climb_pro_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -35064,7 +35296,11 @@ fn field_description_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -35524,7 +35760,11 @@ fn developer_data_id_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -35727,7 +35967,11 @@ fn course_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -35955,7 +36199,11 @@ fn course_point_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -36314,7 +36562,11 @@ fn segment_id_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -36671,7 +36923,11 @@ fn segment_leaderboard_entry_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -36958,7 +37214,11 @@ fn segment_point_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -38384,7 +38644,11 @@ fn segment_lap_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -41037,7 +41301,11 @@ fn segment_file_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -41388,7 +41656,11 @@ fn workout_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -41684,7 +41956,11 @@ fn workout_session_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -43088,7 +43364,11 @@ fn workout_step_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -44722,7 +45002,11 @@ fn exercise_title_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -45034,7 +45318,11 @@ fn schedule_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -45425,7 +45713,11 @@ fn totals_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -45882,7 +46174,11 @@ fn weight_scale_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -46393,7 +46689,11 @@ fn blood_pressure_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -46787,7 +47087,11 @@ fn monitoring_info_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -47448,7 +47752,11 @@ fn monitoring_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -48380,7 +48688,11 @@ fn hr_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -48532,7 +48844,11 @@ fn stress_level_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -48686,7 +49002,11 @@ fn memo_glob_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -48929,7 +49249,11 @@ fn ant_channel_id_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -49185,7 +49509,11 @@ fn ant_rx_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -49441,7 +49769,11 @@ fn ant_tx_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -49645,7 +49977,11 @@ fn exd_screen_configuration_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -49863,7 +50199,11 @@ fn exd_data_field_configuration_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -50173,7 +50513,11 @@ fn exd_data_concept_configuration_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -50701,7 +51045,11 @@ fn dive_summary_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -51218,7 +51566,11 @@ fn hrv_message(
                     value,
                 )?);
             }
-            _ => fields.push(unknown_field(def_num, value)),
+            _ => {
+                if !options.contains(&DecodeOption::DropUnknownFields) {
+                    fields.push(unknown_field(def_num, value));
+                }
+            }
         }
     }
     Ok(fields)
@@ -51251,7 +51603,16 @@ fn hrv_message_time_field(
     )
 }
 
-fn unknown_message(data_map: &HashMap<u8, Value>) -> Result<Vec<FitDataField>> {
+fn unknown_message(
+    data_map: &HashMap<u8, Value>,
+    options: &HashSet<DecodeOption>,
+) -> Result<Vec<FitDataField>> {
+    // since it's an unknown message all the fields are unknown
+    if options.contains(&DecodeOption::DropUnknownFields) {
+        {
+            return Ok(Vec::new());
+        }
+    }
     let fields = data_map
         .iter()
         .map(|(k, v)| unknown_field(*k, v.clone()))
@@ -51400,7 +51761,7 @@ impl MesgNum {
             }
             MesgNum::DiveSummary => dive_summary_message(self, data_map, accumlators, options),
             MesgNum::Hrv => hrv_message(self, data_map, accumlators, options),
-            _ => unknown_message(data_map),
+            _ => unknown_message(data_map, options),
         }
     }
 }

--- a/fitparser/src/profile/decode.rs
+++ b/fitparser/src/profile/decode.rs
@@ -2,9 +2,10 @@
 #![allow(unused_variables)]
 use super::field_types::*;
 use super::{calculate_cumulative_value, data_field_with_info, expand_components, unknown_field};
+use crate::de::DecodeOption;
 use crate::error::Result;
 use crate::{FitDataField, Value};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
 /// FIT SDK version used to generate profile decoder
 pub const VERSION: &str = "21.89.00";
@@ -13,6 +14,7 @@ fn file_id_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -23,6 +25,7 @@ fn file_id_message(
                 fields.push(file_id_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35,6 +38,7 @@ fn file_id_message(
                 fields.push(file_id_message_manufacturer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -54,6 +58,7 @@ fn file_id_message(
                     fields.push(file_id_message_favero_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -71,6 +76,7 @@ fn file_id_message(
                     fields.push(file_id_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -88,6 +94,7 @@ fn file_id_message(
                     fields.push(file_id_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -105,6 +112,7 @@ fn file_id_message(
                     fields.push(file_id_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -122,6 +130,7 @@ fn file_id_message(
                     fields.push(file_id_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -133,6 +142,7 @@ fn file_id_message(
                     fields.push(file_id_message_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -146,6 +156,7 @@ fn file_id_message(
                 fields.push(file_id_message_serial_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -159,6 +170,7 @@ fn file_id_message(
                 fields.push(file_id_message_time_created_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -172,6 +184,7 @@ fn file_id_message(
                 fields.push(file_id_message_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -185,6 +198,7 @@ fn file_id_message(
                 fields.push(file_id_message_product_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -201,6 +215,7 @@ fn file_id_message(
 fn file_id_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -213,11 +228,21 @@ fn file_id_message_type_field(
     } else {
         value
     };
-    data_field_with_info(0, "type", FieldDataType::File, scale, offset, units, value)
+    data_field_with_info(
+        0,
+        "type",
+        FieldDataType::File,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn file_id_message_manufacturer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -238,11 +263,13 @@ fn file_id_message_manufacturer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_id_message_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -263,11 +290,13 @@ fn file_id_message_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_id_message_favero_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -288,11 +317,13 @@ fn file_id_message_favero_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_id_message_garmin_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -313,11 +344,13 @@ fn file_id_message_garmin_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_id_message_serial_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -338,11 +371,13 @@ fn file_id_message_serial_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_id_message_time_created_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -363,11 +398,13 @@ fn file_id_message_time_created_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_id_message_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -388,11 +425,13 @@ fn file_id_message_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_id_message_product_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -413,12 +452,14 @@ fn file_id_message_product_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_creator_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -429,6 +470,7 @@ fn file_creator_message(
                 fields.push(file_creator_message_software_version_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -441,6 +483,7 @@ fn file_creator_message(
                 fields.push(file_creator_message_hardware_version_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -457,6 +500,7 @@ fn file_creator_message(
 fn file_creator_message_software_version_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -477,11 +521,13 @@ fn file_creator_message_software_version_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_creator_message_hardware_version_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -502,12 +548,14 @@ fn file_creator_message_hardware_version_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn timestamp_correlation_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -519,6 +567,7 @@ fn timestamp_correlation_message(
                 fields.push(timestamp_correlation_message_fractional_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     32768.000000,
@@ -532,6 +581,7 @@ fn timestamp_correlation_message(
                 fields.push(timestamp_correlation_message_system_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -546,6 +596,7 @@ fn timestamp_correlation_message(
                     timestamp_correlation_message_fractional_system_timestamp_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         32768.000000,
@@ -560,6 +611,7 @@ fn timestamp_correlation_message(
                 fields.push(timestamp_correlation_message_local_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -573,6 +625,7 @@ fn timestamp_correlation_message(
                 fields.push(timestamp_correlation_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -586,6 +639,7 @@ fn timestamp_correlation_message(
                 fields.push(timestamp_correlation_message_system_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -599,6 +653,7 @@ fn timestamp_correlation_message(
                 fields.push(timestamp_correlation_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -615,6 +670,7 @@ fn timestamp_correlation_message(
 fn timestamp_correlation_message_fractional_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -635,11 +691,13 @@ fn timestamp_correlation_message_fractional_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn timestamp_correlation_message_system_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -660,11 +718,13 @@ fn timestamp_correlation_message_system_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn timestamp_correlation_message_fractional_system_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -685,11 +745,13 @@ fn timestamp_correlation_message_fractional_system_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn timestamp_correlation_message_local_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -710,11 +772,13 @@ fn timestamp_correlation_message_local_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn timestamp_correlation_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -735,11 +799,13 @@ fn timestamp_correlation_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn timestamp_correlation_message_system_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -760,11 +826,13 @@ fn timestamp_correlation_message_system_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn timestamp_correlation_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -785,12 +853,14 @@ fn timestamp_correlation_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn software_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -801,6 +871,7 @@ fn software_message(
                 fields.push(software_message_version_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -813,6 +884,7 @@ fn software_message(
                 fields.push(software_message_part_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -825,6 +897,7 @@ fn software_message(
                 fields.push(software_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -841,6 +914,7 @@ fn software_message(
 fn software_message_version_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -861,11 +935,13 @@ fn software_message_version_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn software_message_part_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -886,11 +962,13 @@ fn software_message_part_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn software_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -911,12 +989,14 @@ fn software_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn slave_device_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -927,6 +1007,7 @@ fn slave_device_message(
                 fields.push(slave_device_message_manufacturer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -946,6 +1027,7 @@ fn slave_device_message(
                     fields.push(slave_device_message_favero_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -963,6 +1045,7 @@ fn slave_device_message(
                     fields.push(slave_device_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -980,6 +1063,7 @@ fn slave_device_message(
                     fields.push(slave_device_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -997,6 +1081,7 @@ fn slave_device_message(
                     fields.push(slave_device_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -1014,6 +1099,7 @@ fn slave_device_message(
                     fields.push(slave_device_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -1025,6 +1111,7 @@ fn slave_device_message(
                     fields.push(slave_device_message_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -1042,6 +1129,7 @@ fn slave_device_message(
 fn slave_device_message_manufacturer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1062,11 +1150,13 @@ fn slave_device_message_manufacturer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn slave_device_message_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1087,11 +1177,13 @@ fn slave_device_message_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn slave_device_message_favero_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1112,11 +1204,13 @@ fn slave_device_message_favero_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn slave_device_message_garmin_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1137,12 +1231,14 @@ fn slave_device_message_garmin_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn capabilities_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -1154,6 +1250,7 @@ fn capabilities_message(
                 fields.push(capabilities_message_languages_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1167,6 +1264,7 @@ fn capabilities_message(
                 fields.push(capabilities_message_sports_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1179,6 +1277,7 @@ fn capabilities_message(
                 fields.push(capabilities_message_workouts_supported_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1191,6 +1290,7 @@ fn capabilities_message(
                 fields.push(capabilities_message_connectivity_supported_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1207,6 +1307,7 @@ fn capabilities_message(
 fn capabilities_message_languages_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1227,11 +1328,13 @@ fn capabilities_message_languages_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn capabilities_message_sports_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1252,11 +1355,13 @@ fn capabilities_message_sports_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn capabilities_message_workouts_supported_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1277,11 +1382,13 @@ fn capabilities_message_workouts_supported_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn capabilities_message_connectivity_supported_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1302,12 +1409,14 @@ fn capabilities_message_connectivity_supported_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_capabilities_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -1318,6 +1427,7 @@ fn file_capabilities_message(
                 fields.push(file_capabilities_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1330,6 +1440,7 @@ fn file_capabilities_message(
                 fields.push(file_capabilities_message_flags_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1342,6 +1453,7 @@ fn file_capabilities_message(
                 fields.push(file_capabilities_message_directory_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1354,6 +1466,7 @@ fn file_capabilities_message(
                 fields.push(file_capabilities_message_max_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1366,6 +1479,7 @@ fn file_capabilities_message(
                 fields.push(file_capabilities_message_max_size_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1378,6 +1492,7 @@ fn file_capabilities_message(
                 fields.push(file_capabilities_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1394,6 +1509,7 @@ fn file_capabilities_message(
 fn file_capabilities_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1406,11 +1522,21 @@ fn file_capabilities_message_type_field(
     } else {
         value
     };
-    data_field_with_info(0, "type", FieldDataType::File, scale, offset, units, value)
+    data_field_with_info(
+        0,
+        "type",
+        FieldDataType::File,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn file_capabilities_message_flags_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1431,11 +1557,13 @@ fn file_capabilities_message_flags_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_capabilities_message_directory_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1456,11 +1584,13 @@ fn file_capabilities_message_directory_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_capabilities_message_max_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1481,11 +1611,13 @@ fn file_capabilities_message_max_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_capabilities_message_max_size_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1506,11 +1638,13 @@ fn file_capabilities_message_max_size_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn file_capabilities_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1531,12 +1665,14 @@ fn file_capabilities_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn mesg_capabilities_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -1547,6 +1683,7 @@ fn mesg_capabilities_message(
                 fields.push(mesg_capabilities_message_file_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1559,6 +1696,7 @@ fn mesg_capabilities_message(
                 fields.push(mesg_capabilities_message_mesg_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1571,6 +1709,7 @@ fn mesg_capabilities_message(
                 fields.push(mesg_capabilities_message_count_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1590,6 +1729,7 @@ fn mesg_capabilities_message(
                     fields.push(mesg_capabilities_message_num_per_file_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -1607,6 +1747,7 @@ fn mesg_capabilities_message(
                     fields.push(mesg_capabilities_message_max_per_file_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -1624,6 +1765,7 @@ fn mesg_capabilities_message(
                     fields.push(mesg_capabilities_message_max_per_file_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -1635,6 +1777,7 @@ fn mesg_capabilities_message(
                     fields.push(mesg_capabilities_message_count_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -1648,6 +1791,7 @@ fn mesg_capabilities_message(
                 fields.push(mesg_capabilities_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1664,6 +1808,7 @@ fn mesg_capabilities_message(
 fn mesg_capabilities_message_file_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1676,11 +1821,21 @@ fn mesg_capabilities_message_file_field(
     } else {
         value
     };
-    data_field_with_info(0, "file", FieldDataType::File, scale, offset, units, value)
+    data_field_with_info(
+        0,
+        "file",
+        FieldDataType::File,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn mesg_capabilities_message_mesg_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1701,11 +1856,13 @@ fn mesg_capabilities_message_mesg_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn mesg_capabilities_message_count_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1726,11 +1883,13 @@ fn mesg_capabilities_message_count_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn mesg_capabilities_message_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1751,11 +1910,13 @@ fn mesg_capabilities_message_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn mesg_capabilities_message_num_per_file_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1776,11 +1937,13 @@ fn mesg_capabilities_message_num_per_file_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn mesg_capabilities_message_max_per_file_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1801,11 +1964,13 @@ fn mesg_capabilities_message_max_per_file_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn mesg_capabilities_message_max_per_file_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1826,11 +1991,13 @@ fn mesg_capabilities_message_max_per_file_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn mesg_capabilities_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1851,12 +2018,14 @@ fn mesg_capabilities_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_capabilities_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -1867,6 +2036,7 @@ fn field_capabilities_message(
                 fields.push(field_capabilities_message_file_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1879,6 +2049,7 @@ fn field_capabilities_message(
                 fields.push(field_capabilities_message_mesg_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1891,6 +2062,7 @@ fn field_capabilities_message(
                 fields.push(field_capabilities_message_field_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1903,6 +2075,7 @@ fn field_capabilities_message(
                 fields.push(field_capabilities_message_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1915,6 +2088,7 @@ fn field_capabilities_message(
                 fields.push(field_capabilities_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -1931,6 +2105,7 @@ fn field_capabilities_message(
 fn field_capabilities_message_file_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1943,11 +2118,21 @@ fn field_capabilities_message_file_field(
     } else {
         value
     };
-    data_field_with_info(0, "file", FieldDataType::File, scale, offset, units, value)
+    data_field_with_info(
+        0,
+        "file",
+        FieldDataType::File,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn field_capabilities_message_mesg_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1968,11 +2153,13 @@ fn field_capabilities_message_mesg_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_capabilities_message_field_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -1993,11 +2180,13 @@ fn field_capabilities_message_field_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_capabilities_message_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2018,11 +2207,13 @@ fn field_capabilities_message_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_capabilities_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2043,12 +2234,14 @@ fn field_capabilities_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -2060,6 +2253,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_active_time_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2073,6 +2267,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_utc_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2086,6 +2281,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_time_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2099,6 +2295,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_time_mode_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2112,6 +2309,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_time_zone_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     4.000000,
@@ -2125,6 +2323,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_backlight_mode_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2138,6 +2337,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_activity_tracker_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2151,6 +2351,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_clock_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2164,6 +2365,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_pages_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2177,6 +2379,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_move_alert_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2190,6 +2393,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_date_mode_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2202,6 +2406,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_display_orientation_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2214,6 +2419,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_mounting_side_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2227,6 +2433,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_default_page_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2240,6 +2447,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_autosync_min_steps_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2253,6 +2461,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_autosync_min_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2267,6 +2476,7 @@ fn device_settings_message(
                     device_settings_message_lactate_threshold_autodetect_enabled_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -2281,6 +2491,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_ble_auto_upload_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2294,6 +2505,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_auto_sync_frequency_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2307,6 +2519,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_auto_activity_detect_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2320,6 +2533,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_number_of_screens_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2334,6 +2548,7 @@ fn device_settings_message(
                     device_settings_message_smart_notification_display_orientation_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -2347,6 +2562,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_tap_interface_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2360,6 +2576,7 @@ fn device_settings_message(
                 fields.push(device_settings_message_tap_sensitivity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2376,6 +2593,7 @@ fn device_settings_message(
 fn device_settings_message_active_time_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2396,11 +2614,13 @@ fn device_settings_message_active_time_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_utc_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2421,11 +2641,13 @@ fn device_settings_message_utc_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_time_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2446,11 +2668,13 @@ fn device_settings_message_time_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_time_mode_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2471,11 +2695,13 @@ fn device_settings_message_time_mode_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_time_zone_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2496,11 +2722,13 @@ fn device_settings_message_time_zone_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_backlight_mode_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2521,11 +2749,13 @@ fn device_settings_message_backlight_mode_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_activity_tracker_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2546,11 +2776,13 @@ fn device_settings_message_activity_tracker_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_clock_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2571,11 +2803,13 @@ fn device_settings_message_clock_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_pages_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2596,11 +2830,13 @@ fn device_settings_message_pages_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_move_alert_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2621,11 +2857,13 @@ fn device_settings_message_move_alert_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_date_mode_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2646,11 +2884,13 @@ fn device_settings_message_date_mode_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_display_orientation_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2671,11 +2911,13 @@ fn device_settings_message_display_orientation_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_mounting_side_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2696,11 +2938,13 @@ fn device_settings_message_mounting_side_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_default_page_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2721,11 +2965,13 @@ fn device_settings_message_default_page_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_autosync_min_steps_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2746,11 +2992,13 @@ fn device_settings_message_autosync_min_steps_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_autosync_min_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2771,11 +3019,13 @@ fn device_settings_message_autosync_min_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_lactate_threshold_autodetect_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2796,11 +3046,13 @@ fn device_settings_message_lactate_threshold_autodetect_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_ble_auto_upload_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2821,11 +3073,13 @@ fn device_settings_message_ble_auto_upload_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_auto_sync_frequency_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2846,11 +3100,13 @@ fn device_settings_message_auto_sync_frequency_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_auto_activity_detect_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2871,11 +3127,13 @@ fn device_settings_message_auto_activity_detect_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_number_of_screens_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2896,11 +3154,13 @@ fn device_settings_message_number_of_screens_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_smart_notification_display_orientation_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2921,11 +3181,13 @@ fn device_settings_message_smart_notification_display_orientation_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_tap_interface_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2946,11 +3208,13 @@ fn device_settings_message_tap_interface_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_settings_message_tap_sensitivity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -2971,12 +3235,14 @@ fn device_settings_message_tap_sensitivity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -2987,6 +3253,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_friendly_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -2999,6 +3266,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_gender_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3011,6 +3279,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_age_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3023,6 +3292,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_height_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -3035,6 +3305,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_weight_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -3047,6 +3318,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_language_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3059,6 +3331,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_elev_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3071,6 +3344,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_weight_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3083,6 +3357,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_resting_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3095,6 +3370,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_default_max_running_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3107,6 +3383,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_default_max_biking_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3119,6 +3396,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_default_max_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3131,6 +3409,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_hr_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3143,6 +3422,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_speed_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3155,6 +3435,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_dist_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3167,6 +3448,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_power_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3179,6 +3461,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_activity_class_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3191,6 +3474,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_position_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3203,6 +3487,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_temperature_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3215,6 +3500,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_local_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3227,6 +3513,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_global_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3240,6 +3527,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_wake_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3253,6 +3541,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_sleep_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3265,6 +3554,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_height_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3278,6 +3568,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_user_running_step_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -3291,6 +3582,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_user_walking_step_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -3303,6 +3595,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_depth_setting_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3315,6 +3608,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_dive_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3327,6 +3621,7 @@ fn user_profile_message(
                 fields.push(user_profile_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -3343,6 +3638,7 @@ fn user_profile_message(
 fn user_profile_message_friendly_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3363,11 +3659,13 @@ fn user_profile_message_friendly_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_gender_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3388,11 +3686,13 @@ fn user_profile_message_gender_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_age_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3405,11 +3705,21 @@ fn user_profile_message_age_field(
     } else {
         value
     };
-    data_field_with_info(2, "age", FieldDataType::UInt8, scale, offset, units, value)
+    data_field_with_info(
+        2,
+        "age",
+        FieldDataType::UInt8,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn user_profile_message_height_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3430,11 +3740,13 @@ fn user_profile_message_height_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_weight_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3455,11 +3767,13 @@ fn user_profile_message_weight_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_language_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3480,11 +3794,13 @@ fn user_profile_message_language_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_elev_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3505,11 +3821,13 @@ fn user_profile_message_elev_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_weight_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3530,11 +3848,13 @@ fn user_profile_message_weight_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_resting_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3555,11 +3875,13 @@ fn user_profile_message_resting_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_default_max_running_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3580,11 +3902,13 @@ fn user_profile_message_default_max_running_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_default_max_biking_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3605,11 +3929,13 @@ fn user_profile_message_default_max_biking_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_default_max_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3630,11 +3956,13 @@ fn user_profile_message_default_max_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_hr_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3655,11 +3983,13 @@ fn user_profile_message_hr_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_speed_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3680,11 +4010,13 @@ fn user_profile_message_speed_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_dist_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3705,11 +4037,13 @@ fn user_profile_message_dist_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_power_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3730,11 +4064,13 @@ fn user_profile_message_power_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_activity_class_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3755,11 +4091,13 @@ fn user_profile_message_activity_class_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_position_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3780,11 +4118,13 @@ fn user_profile_message_position_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_temperature_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3805,11 +4145,13 @@ fn user_profile_message_temperature_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_local_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3830,11 +4172,13 @@ fn user_profile_message_local_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_global_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3855,11 +4199,13 @@ fn user_profile_message_global_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_wake_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3880,11 +4226,13 @@ fn user_profile_message_wake_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_sleep_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3905,11 +4253,13 @@ fn user_profile_message_sleep_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_height_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3930,11 +4280,13 @@ fn user_profile_message_height_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_user_running_step_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3955,11 +4307,13 @@ fn user_profile_message_user_running_step_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_user_walking_step_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -3980,11 +4334,13 @@ fn user_profile_message_user_walking_step_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_depth_setting_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4005,11 +4361,13 @@ fn user_profile_message_depth_setting_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_dive_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4030,11 +4388,13 @@ fn user_profile_message_dive_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn user_profile_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4055,12 +4415,14 @@ fn user_profile_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hrm_profile_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -4071,6 +4433,7 @@ fn hrm_profile_message(
                 fields.push(hrm_profile_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4083,6 +4446,7 @@ fn hrm_profile_message(
                 fields.push(hrm_profile_message_hrm_ant_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4095,6 +4459,7 @@ fn hrm_profile_message(
                 fields.push(hrm_profile_message_log_hrv_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4107,6 +4472,7 @@ fn hrm_profile_message(
                 fields.push(hrm_profile_message_hrm_ant_id_trans_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4119,6 +4485,7 @@ fn hrm_profile_message(
                 fields.push(hrm_profile_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4135,6 +4502,7 @@ fn hrm_profile_message(
 fn hrm_profile_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4155,11 +4523,13 @@ fn hrm_profile_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hrm_profile_message_hrm_ant_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4180,11 +4550,13 @@ fn hrm_profile_message_hrm_ant_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hrm_profile_message_log_hrv_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4205,11 +4577,13 @@ fn hrm_profile_message_log_hrv_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hrm_profile_message_hrm_ant_id_trans_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4230,11 +4604,13 @@ fn hrm_profile_message_hrm_ant_id_trans_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hrm_profile_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4255,12 +4631,14 @@ fn hrm_profile_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -4271,6 +4649,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4283,6 +4662,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_sdm_ant_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4295,6 +4675,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_sdm_cal_factor_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -4307,6 +4688,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_odometer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -4320,6 +4702,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_speed_source_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4332,6 +4715,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_sdm_ant_id_trans_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4345,6 +4729,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_odometer_rollover_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4357,6 +4742,7 @@ fn sdm_profile_message(
                 fields.push(sdm_profile_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4373,6 +4759,7 @@ fn sdm_profile_message(
 fn sdm_profile_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4393,11 +4780,13 @@ fn sdm_profile_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message_sdm_ant_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4418,11 +4807,13 @@ fn sdm_profile_message_sdm_ant_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message_sdm_cal_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4443,11 +4834,13 @@ fn sdm_profile_message_sdm_cal_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message_odometer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4468,11 +4861,13 @@ fn sdm_profile_message_odometer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message_speed_source_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4493,11 +4888,13 @@ fn sdm_profile_message_speed_source_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message_sdm_ant_id_trans_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4518,11 +4915,13 @@ fn sdm_profile_message_sdm_ant_id_trans_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message_odometer_rollover_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4543,11 +4942,13 @@ fn sdm_profile_message_odometer_rollover_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sdm_profile_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4568,12 +4969,14 @@ fn sdm_profile_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -4584,6 +4987,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4596,6 +5000,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4608,6 +5013,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4620,6 +5026,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_odometer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -4632,6 +5039,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_spd_ant_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4644,6 +5052,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_cad_ant_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4656,6 +5065,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_spdcad_ant_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4668,6 +5078,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_power_ant_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4680,6 +5091,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_custom_wheelsize_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -4692,6 +5104,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_auto_wheelsize_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -4704,6 +5117,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_weight_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -4716,6 +5130,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_power_cal_factor_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -4728,6 +5143,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_auto_wheel_cal_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4740,6 +5156,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_auto_power_zero_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4752,6 +5169,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4764,6 +5182,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_spd_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4776,6 +5195,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_cad_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4788,6 +5208,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_spdcad_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4800,6 +5221,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_power_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4812,6 +5234,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_crank_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -4824,6 +5247,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4836,6 +5260,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_spd_ant_id_trans_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4848,6 +5273,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_cad_ant_id_trans_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4860,6 +5286,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_spdcad_ant_id_trans_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4872,6 +5299,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_bike_power_ant_id_trans_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4885,6 +5313,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_odometer_rollover_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4898,6 +5327,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_front_gear_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4911,6 +5341,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_front_gear_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4924,6 +5355,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_rear_gear_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4937,6 +5369,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_rear_gear_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4949,6 +5382,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_shimano_di2_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4961,6 +5395,7 @@ fn bike_profile_message(
                 fields.push(bike_profile_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -4977,6 +5412,7 @@ fn bike_profile_message(
 fn bike_profile_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -4997,11 +5433,13 @@ fn bike_profile_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5022,11 +5460,13 @@ fn bike_profile_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5047,11 +5487,13 @@ fn bike_profile_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_odometer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5072,11 +5514,13 @@ fn bike_profile_message_odometer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_spd_ant_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5097,11 +5541,13 @@ fn bike_profile_message_bike_spd_ant_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_cad_ant_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5122,11 +5568,13 @@ fn bike_profile_message_bike_cad_ant_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_spdcad_ant_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5147,11 +5595,13 @@ fn bike_profile_message_bike_spdcad_ant_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_power_ant_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5172,11 +5622,13 @@ fn bike_profile_message_bike_power_ant_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_custom_wheelsize_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5197,11 +5649,13 @@ fn bike_profile_message_custom_wheelsize_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_auto_wheelsize_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5222,11 +5676,13 @@ fn bike_profile_message_auto_wheelsize_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_weight_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5247,11 +5703,13 @@ fn bike_profile_message_bike_weight_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_power_cal_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5272,11 +5730,13 @@ fn bike_profile_message_power_cal_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_auto_wheel_cal_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5297,11 +5757,13 @@ fn bike_profile_message_auto_wheel_cal_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_auto_power_zero_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5322,11 +5784,13 @@ fn bike_profile_message_auto_power_zero_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5339,11 +5803,21 @@ fn bike_profile_message_id_field(
     } else {
         value
     };
-    data_field_with_info(14, "id", FieldDataType::UInt8, scale, offset, units, value)
+    data_field_with_info(
+        14,
+        "id",
+        FieldDataType::UInt8,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn bike_profile_message_spd_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5364,11 +5838,13 @@ fn bike_profile_message_spd_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_cad_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5389,11 +5865,13 @@ fn bike_profile_message_cad_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_spdcad_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5414,11 +5892,13 @@ fn bike_profile_message_spdcad_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_power_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5439,11 +5919,13 @@ fn bike_profile_message_power_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_crank_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5464,11 +5946,13 @@ fn bike_profile_message_crank_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5489,11 +5973,13 @@ fn bike_profile_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_spd_ant_id_trans_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5514,11 +6000,13 @@ fn bike_profile_message_bike_spd_ant_id_trans_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_cad_ant_id_trans_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5539,11 +6027,13 @@ fn bike_profile_message_bike_cad_ant_id_trans_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_spdcad_ant_id_trans_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5564,11 +6054,13 @@ fn bike_profile_message_bike_spdcad_ant_id_trans_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_bike_power_ant_id_trans_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5589,11 +6081,13 @@ fn bike_profile_message_bike_power_ant_id_trans_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_odometer_rollover_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5614,11 +6108,13 @@ fn bike_profile_message_odometer_rollover_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_front_gear_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5639,11 +6135,13 @@ fn bike_profile_message_front_gear_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_front_gear_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5664,11 +6162,13 @@ fn bike_profile_message_front_gear_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_rear_gear_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5689,11 +6189,13 @@ fn bike_profile_message_rear_gear_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_rear_gear_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5714,11 +6216,13 @@ fn bike_profile_message_rear_gear_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_shimano_di2_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5739,11 +6243,13 @@ fn bike_profile_message_shimano_di2_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn bike_profile_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5764,12 +6270,14 @@ fn bike_profile_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -5781,6 +6289,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_bluetooth_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5794,6 +6303,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_bluetooth_le_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5807,6 +6317,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_ant_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5819,6 +6330,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5831,6 +6343,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_live_tracking_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5843,6 +6356,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_weather_conditions_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5855,6 +6369,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_weather_alerts_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5867,6 +6382,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_auto_activity_upload_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5879,6 +6395,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_course_download_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5891,6 +6408,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_workout_download_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5903,6 +6421,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_gps_ephemeris_download_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5915,6 +6434,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_incident_detection_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5927,6 +6447,7 @@ fn connectivity_message(
                 fields.push(connectivity_message_grouptrack_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -5943,6 +6464,7 @@ fn connectivity_message(
 fn connectivity_message_bluetooth_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5963,11 +6485,13 @@ fn connectivity_message_bluetooth_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_bluetooth_le_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -5988,11 +6512,13 @@ fn connectivity_message_bluetooth_le_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_ant_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6013,11 +6539,13 @@ fn connectivity_message_ant_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6038,11 +6566,13 @@ fn connectivity_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_live_tracking_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6063,11 +6593,13 @@ fn connectivity_message_live_tracking_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_weather_conditions_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6088,11 +6620,13 @@ fn connectivity_message_weather_conditions_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_weather_alerts_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6113,11 +6647,13 @@ fn connectivity_message_weather_alerts_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_auto_activity_upload_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6138,11 +6674,13 @@ fn connectivity_message_auto_activity_upload_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_course_download_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6163,11 +6701,13 @@ fn connectivity_message_course_download_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_workout_download_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6188,11 +6728,13 @@ fn connectivity_message_workout_download_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_gps_ephemeris_download_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6213,11 +6755,13 @@ fn connectivity_message_gps_ephemeris_download_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_incident_detection_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6238,11 +6782,13 @@ fn connectivity_message_incident_detection_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn connectivity_message_grouptrack_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6263,12 +6809,14 @@ fn connectivity_message_grouptrack_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn watchface_settings_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -6279,6 +6827,7 @@ fn watchface_settings_message(
                 fields.push(watchface_settings_message_mode_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6298,6 +6847,7 @@ fn watchface_settings_message(
                     fields.push(watchface_settings_message_digital_layout_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -6315,6 +6865,7 @@ fn watchface_settings_message(
                     fields.push(watchface_settings_message_analog_layout_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -6326,6 +6877,7 @@ fn watchface_settings_message(
                     fields.push(watchface_settings_message_layout_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -6339,6 +6891,7 @@ fn watchface_settings_message(
                 fields.push(watchface_settings_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6355,6 +6908,7 @@ fn watchface_settings_message(
 fn watchface_settings_message_mode_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6375,11 +6929,13 @@ fn watchface_settings_message_mode_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn watchface_settings_message_layout_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6400,11 +6956,13 @@ fn watchface_settings_message_layout_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn watchface_settings_message_digital_layout_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6425,11 +6983,13 @@ fn watchface_settings_message_digital_layout_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn watchface_settings_message_analog_layout_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6450,11 +7010,13 @@ fn watchface_settings_message_analog_layout_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn watchface_settings_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6475,12 +7037,14 @@ fn watchface_settings_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ohr_settings_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -6491,6 +7055,7 @@ fn ohr_settings_message(
                 fields.push(ohr_settings_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6503,6 +7068,7 @@ fn ohr_settings_message(
                 fields.push(ohr_settings_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6519,6 +7085,7 @@ fn ohr_settings_message(
 fn ohr_settings_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6539,11 +7106,13 @@ fn ohr_settings_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ohr_settings_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6564,12 +7133,14 @@ fn ohr_settings_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn zones_target_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -6580,6 +7151,7 @@ fn zones_target_message(
                 fields.push(zones_target_message_max_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6592,6 +7164,7 @@ fn zones_target_message(
                 fields.push(zones_target_message_threshold_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6604,6 +7177,7 @@ fn zones_target_message(
                 fields.push(zones_target_message_functional_threshold_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6616,6 +7190,7 @@ fn zones_target_message(
                 fields.push(zones_target_message_hr_calc_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6628,6 +7203,7 @@ fn zones_target_message(
                 fields.push(zones_target_message_pwr_calc_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6644,6 +7220,7 @@ fn zones_target_message(
 fn zones_target_message_max_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6664,11 +7241,13 @@ fn zones_target_message_max_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn zones_target_message_threshold_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6689,11 +7268,13 @@ fn zones_target_message_threshold_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn zones_target_message_functional_threshold_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6714,11 +7295,13 @@ fn zones_target_message_functional_threshold_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn zones_target_message_hr_calc_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6739,11 +7322,13 @@ fn zones_target_message_hr_calc_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn zones_target_message_pwr_calc_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6764,12 +7349,14 @@ fn zones_target_message_pwr_calc_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sport_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -6780,6 +7367,7 @@ fn sport_message(
                 fields.push(sport_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6792,6 +7380,7 @@ fn sport_message(
                 fields.push(sport_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6804,6 +7393,7 @@ fn sport_message(
                 fields.push(sport_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6820,6 +7410,7 @@ fn sport_message(
 fn sport_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6840,11 +7431,13 @@ fn sport_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sport_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6865,11 +7458,13 @@ fn sport_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn sport_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6890,12 +7485,14 @@ fn sport_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hr_zone_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -6906,6 +7503,7 @@ fn hr_zone_message(
                 fields.push(hr_zone_message_high_bpm_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6918,6 +7516,7 @@ fn hr_zone_message(
                 fields.push(hr_zone_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6930,6 +7529,7 @@ fn hr_zone_message(
                 fields.push(hr_zone_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -6946,6 +7546,7 @@ fn hr_zone_message(
 fn hr_zone_message_high_bpm_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6966,11 +7567,13 @@ fn hr_zone_message_high_bpm_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hr_zone_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -6991,11 +7594,13 @@ fn hr_zone_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hr_zone_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7016,12 +7621,14 @@ fn hr_zone_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn speed_zone_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -7032,6 +7639,7 @@ fn speed_zone_message(
                 fields.push(speed_zone_message_high_value_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -7044,6 +7652,7 @@ fn speed_zone_message(
                 fields.push(speed_zone_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7056,6 +7665,7 @@ fn speed_zone_message(
                 fields.push(speed_zone_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7072,6 +7682,7 @@ fn speed_zone_message(
 fn speed_zone_message_high_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7092,11 +7703,13 @@ fn speed_zone_message_high_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn speed_zone_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7117,11 +7730,13 @@ fn speed_zone_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn speed_zone_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7142,12 +7757,14 @@ fn speed_zone_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn cadence_zone_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -7158,6 +7775,7 @@ fn cadence_zone_message(
                 fields.push(cadence_zone_message_high_value_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7170,6 +7788,7 @@ fn cadence_zone_message(
                 fields.push(cadence_zone_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7182,6 +7801,7 @@ fn cadence_zone_message(
                 fields.push(cadence_zone_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7198,6 +7818,7 @@ fn cadence_zone_message(
 fn cadence_zone_message_high_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7218,11 +7839,13 @@ fn cadence_zone_message_high_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn cadence_zone_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7243,11 +7866,13 @@ fn cadence_zone_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn cadence_zone_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7268,12 +7893,14 @@ fn cadence_zone_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn power_zone_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -7284,6 +7911,7 @@ fn power_zone_message(
                 fields.push(power_zone_message_high_value_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7296,6 +7924,7 @@ fn power_zone_message(
                 fields.push(power_zone_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7308,6 +7937,7 @@ fn power_zone_message(
                 fields.push(power_zone_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7324,6 +7954,7 @@ fn power_zone_message(
 fn power_zone_message_high_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7344,11 +7975,13 @@ fn power_zone_message_high_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn power_zone_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7369,11 +8002,13 @@ fn power_zone_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn power_zone_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7394,12 +8029,14 @@ fn power_zone_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn met_zone_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -7410,6 +8047,7 @@ fn met_zone_message(
                 fields.push(met_zone_message_high_bpm_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7422,6 +8060,7 @@ fn met_zone_message(
                 fields.push(met_zone_message_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -7434,6 +8073,7 @@ fn met_zone_message(
                 fields.push(met_zone_message_fat_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -7446,6 +8086,7 @@ fn met_zone_message(
                 fields.push(met_zone_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7462,6 +8103,7 @@ fn met_zone_message(
 fn met_zone_message_high_bpm_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7482,11 +8124,13 @@ fn met_zone_message_high_bpm_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn met_zone_message_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7507,11 +8151,13 @@ fn met_zone_message_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn met_zone_message_fat_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7532,11 +8178,13 @@ fn met_zone_message_fat_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn met_zone_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7557,12 +8205,14 @@ fn met_zone_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -7573,6 +8223,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7585,6 +8236,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_model_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7597,6 +8249,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_gf_low_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7609,6 +8262,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_gf_high_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7621,6 +8275,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_water_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7634,6 +8289,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_water_density_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7647,6 +8303,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_po2_warn_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -7660,6 +8317,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_po2_critical_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -7672,6 +8330,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_po2_deco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -7684,6 +8343,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_safety_stop_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7696,6 +8356,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_bottom_depth_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7708,6 +8369,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_bottom_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7720,6 +8382,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_apnea_countdown_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7732,6 +8395,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_apnea_countdown_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7744,6 +8408,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_backlight_mode_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7756,6 +8421,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_backlight_brightness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7768,6 +8434,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_backlight_timeout_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7781,6 +8448,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_repeat_dive_interval_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7794,6 +8462,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_safety_stop_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7806,6 +8475,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_heart_rate_source_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7825,6 +8495,7 @@ fn dive_settings_message(
                     fields.push(dive_settings_message_heart_rate_antplus_device_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -7842,6 +8513,7 @@ fn dive_settings_message(
                     fields.push(dive_settings_message_heart_rate_local_device_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -7853,6 +8525,7 @@ fn dive_settings_message(
                     fields.push(dive_settings_message_heart_rate_source_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -7866,6 +8539,7 @@ fn dive_settings_message(
                 fields.push(dive_settings_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -7882,6 +8556,7 @@ fn dive_settings_message(
 fn dive_settings_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7902,11 +8577,13 @@ fn dive_settings_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_model_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7927,11 +8604,13 @@ fn dive_settings_message_model_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_gf_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7952,11 +8631,13 @@ fn dive_settings_message_gf_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_gf_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -7977,11 +8658,13 @@ fn dive_settings_message_gf_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_water_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8002,11 +8685,13 @@ fn dive_settings_message_water_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_water_density_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8027,11 +8712,13 @@ fn dive_settings_message_water_density_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_po2_warn_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8052,11 +8739,13 @@ fn dive_settings_message_po2_warn_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_po2_critical_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8077,11 +8766,13 @@ fn dive_settings_message_po2_critical_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_po2_deco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8102,11 +8793,13 @@ fn dive_settings_message_po2_deco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_safety_stop_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8127,11 +8820,13 @@ fn dive_settings_message_safety_stop_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_bottom_depth_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8152,11 +8847,13 @@ fn dive_settings_message_bottom_depth_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_bottom_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8177,11 +8874,13 @@ fn dive_settings_message_bottom_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_apnea_countdown_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8202,11 +8901,13 @@ fn dive_settings_message_apnea_countdown_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_apnea_countdown_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8227,11 +8928,13 @@ fn dive_settings_message_apnea_countdown_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_backlight_mode_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8252,11 +8955,13 @@ fn dive_settings_message_backlight_mode_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_backlight_brightness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8277,11 +8982,13 @@ fn dive_settings_message_backlight_brightness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_backlight_timeout_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8302,11 +9009,13 @@ fn dive_settings_message_backlight_timeout_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_repeat_dive_interval_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8327,11 +9036,13 @@ fn dive_settings_message_repeat_dive_interval_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_safety_stop_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8352,11 +9063,13 @@ fn dive_settings_message_safety_stop_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_heart_rate_source_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8377,11 +9090,13 @@ fn dive_settings_message_heart_rate_source_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_heart_rate_source_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8402,11 +9117,13 @@ fn dive_settings_message_heart_rate_source_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_heart_rate_antplus_device_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8427,11 +9144,13 @@ fn dive_settings_message_heart_rate_antplus_device_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_heart_rate_local_device_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8452,11 +9171,13 @@ fn dive_settings_message_heart_rate_local_device_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_settings_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8477,12 +9198,14 @@ fn dive_settings_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_alarm_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -8494,6 +9217,7 @@ fn dive_alarm_message(
                 fields.push(dive_alarm_message_depth_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -8507,6 +9231,7 @@ fn dive_alarm_message(
                 fields.push(dive_alarm_message_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8520,6 +9245,7 @@ fn dive_alarm_message(
                 fields.push(dive_alarm_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8533,6 +9259,7 @@ fn dive_alarm_message(
                 fields.push(dive_alarm_message_alarm_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8546,6 +9273,7 @@ fn dive_alarm_message(
                 fields.push(dive_alarm_message_sound_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8559,6 +9287,7 @@ fn dive_alarm_message(
                 fields.push(dive_alarm_message_dive_types_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8572,6 +9301,7 @@ fn dive_alarm_message(
                 fields.push(dive_alarm_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8588,6 +9318,7 @@ fn dive_alarm_message(
 fn dive_alarm_message_depth_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8608,11 +9339,13 @@ fn dive_alarm_message_depth_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_alarm_message_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8633,11 +9366,13 @@ fn dive_alarm_message_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_alarm_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8658,11 +9393,13 @@ fn dive_alarm_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_alarm_message_alarm_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8683,11 +9420,13 @@ fn dive_alarm_message_alarm_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_alarm_message_sound_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8700,11 +9439,21 @@ fn dive_alarm_message_sound_field(
     } else {
         value
     };
-    data_field_with_info(4, "sound", FieldDataType::Tone, scale, offset, units, value)
+    data_field_with_info(
+        4,
+        "sound",
+        FieldDataType::Tone,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn dive_alarm_message_dive_types_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8725,11 +9474,13 @@ fn dive_alarm_message_dive_types_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_alarm_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8750,12 +9501,14 @@ fn dive_alarm_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_gas_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -8766,6 +9519,7 @@ fn dive_gas_message(
                 fields.push(dive_gas_message_helium_content_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8778,6 +9532,7 @@ fn dive_gas_message(
                 fields.push(dive_gas_message_oxygen_content_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8790,6 +9545,7 @@ fn dive_gas_message(
                 fields.push(dive_gas_message_status_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8802,6 +9558,7 @@ fn dive_gas_message(
                 fields.push(dive_gas_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8818,6 +9575,7 @@ fn dive_gas_message(
 fn dive_gas_message_helium_content_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8838,11 +9596,13 @@ fn dive_gas_message_helium_content_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_gas_message_oxygen_content_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8863,11 +9623,13 @@ fn dive_gas_message_oxygen_content_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_gas_message_status_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8888,11 +9650,13 @@ fn dive_gas_message_status_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_gas_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -8913,12 +9677,14 @@ fn dive_gas_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -8929,6 +9695,7 @@ fn goal_message(
                 fields.push(goal_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8941,6 +9708,7 @@ fn goal_message(
                 fields.push(goal_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8953,6 +9721,7 @@ fn goal_message(
                 fields.push(goal_message_start_date_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8965,6 +9734,7 @@ fn goal_message(
                 fields.push(goal_message_end_date_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8977,6 +9747,7 @@ fn goal_message(
                 fields.push(goal_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -8989,6 +9760,7 @@ fn goal_message(
                 fields.push(goal_message_value_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9001,6 +9773,7 @@ fn goal_message(
                 fields.push(goal_message_repeat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9013,6 +9786,7 @@ fn goal_message(
                 fields.push(goal_message_target_value_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9025,6 +9799,7 @@ fn goal_message(
                 fields.push(goal_message_recurrence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9037,6 +9812,7 @@ fn goal_message(
                 fields.push(goal_message_recurrence_value_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9049,6 +9825,7 @@ fn goal_message(
                 fields.push(goal_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9061,6 +9838,7 @@ fn goal_message(
                 fields.push(goal_message_source_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9073,6 +9851,7 @@ fn goal_message(
                 fields.push(goal_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9089,6 +9868,7 @@ fn goal_message(
 fn goal_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9109,11 +9889,13 @@ fn goal_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9134,11 +9916,13 @@ fn goal_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_start_date_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9159,11 +9943,13 @@ fn goal_message_start_date_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_end_date_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9184,11 +9970,13 @@ fn goal_message_end_date_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9201,11 +9989,21 @@ fn goal_message_type_field(
     } else {
         value
     };
-    data_field_with_info(4, "type", FieldDataType::Goal, scale, offset, units, value)
+    data_field_with_info(
+        4,
+        "type",
+        FieldDataType::Goal,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn goal_message_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9226,11 +10024,13 @@ fn goal_message_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_repeat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9251,11 +10051,13 @@ fn goal_message_repeat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_target_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9276,11 +10078,13 @@ fn goal_message_target_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_recurrence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9301,11 +10105,13 @@ fn goal_message_recurrence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_recurrence_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9326,11 +10132,13 @@ fn goal_message_recurrence_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9351,11 +10159,13 @@ fn goal_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_source_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9376,11 +10186,13 @@ fn goal_message_source_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn goal_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9401,12 +10213,14 @@ fn goal_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -9418,6 +10232,7 @@ fn activity_message(
                 fields.push(activity_message_total_timer_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -9430,6 +10245,7 @@ fn activity_message(
                 fields.push(activity_message_num_sessions_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9442,6 +10258,7 @@ fn activity_message(
                 fields.push(activity_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9454,6 +10271,7 @@ fn activity_message(
                 fields.push(activity_message_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9466,6 +10284,7 @@ fn activity_message(
                 fields.push(activity_message_event_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9479,6 +10298,7 @@ fn activity_message(
                 fields.push(activity_message_local_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9491,6 +10311,7 @@ fn activity_message(
                 fields.push(activity_message_event_group_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9503,6 +10324,7 @@ fn activity_message(
                 fields.push(activity_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9519,6 +10341,7 @@ fn activity_message(
 fn activity_message_total_timer_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9539,11 +10362,13 @@ fn activity_message_total_timer_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message_num_sessions_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9564,11 +10389,13 @@ fn activity_message_num_sessions_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9589,11 +10416,13 @@ fn activity_message_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9614,11 +10443,13 @@ fn activity_message_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message_event_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9639,11 +10470,13 @@ fn activity_message_event_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message_local_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9664,11 +10497,13 @@ fn activity_message_local_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message_event_group_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9689,11 +10524,13 @@ fn activity_message_event_group_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn activity_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -9714,12 +10551,14 @@ fn activity_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -9731,6 +10570,7 @@ fn session_message(
                 fields.push(session_message_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9744,6 +10584,7 @@ fn session_message(
                 fields.push(session_message_event_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9756,6 +10597,7 @@ fn session_message(
                 fields.push(session_message_start_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9768,6 +10610,7 @@ fn session_message(
                 fields.push(session_message_start_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9780,6 +10623,7 @@ fn session_message(
                 fields.push(session_message_start_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9792,6 +10636,7 @@ fn session_message(
                 fields.push(session_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9804,6 +10649,7 @@ fn session_message(
                 fields.push(session_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9817,6 +10663,7 @@ fn session_message(
                 fields.push(session_message_total_elapsed_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -9830,6 +10677,7 @@ fn session_message(
                 fields.push(session_message_total_timer_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -9842,6 +10690,7 @@ fn session_message(
                 fields.push(session_message_total_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -9861,6 +10710,7 @@ fn session_message(
                     fields.push(session_message_total_strides_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -9878,6 +10728,7 @@ fn session_message(
                     fields.push(session_message_total_strides_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -9895,6 +10746,7 @@ fn session_message(
                     fields.push(session_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -9912,6 +10764,7 @@ fn session_message(
                     fields.push(session_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -9929,6 +10782,7 @@ fn session_message(
                     fields.push(session_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -9946,6 +10800,7 @@ fn session_message(
                     fields.push(session_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -9957,6 +10812,7 @@ fn session_message(
                     fields.push(session_message_total_cycles_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -9970,6 +10826,7 @@ fn session_message(
                 fields.push(session_message_total_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9982,6 +10839,7 @@ fn session_message(
                 fields.push(session_message_total_fat_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -9999,6 +10857,7 @@ fn session_message(
                 fields.push(session_message_enhanced_avg_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10014,6 +10873,7 @@ fn session_message(
                 fields.push(session_message_enhanced_max_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10027,6 +10887,7 @@ fn session_message(
                 fields.push(session_message_avg_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10039,6 +10900,7 @@ fn session_message(
                 fields.push(session_message_max_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10059,6 +10921,7 @@ fn session_message(
                     fields.push(session_message_avg_running_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -10070,6 +10933,7 @@ fn session_message(
                     fields.push(session_message_avg_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -10090,6 +10954,7 @@ fn session_message(
                     fields.push(session_message_max_running_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -10101,6 +10966,7 @@ fn session_message(
                     fields.push(session_message_max_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -10115,6 +10981,7 @@ fn session_message(
                 fields.push(session_message_avg_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10127,6 +10994,7 @@ fn session_message(
                 fields.push(session_message_max_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10139,6 +11007,7 @@ fn session_message(
                 fields.push(session_message_total_ascent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10151,6 +11020,7 @@ fn session_message(
                 fields.push(session_message_total_descent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10163,6 +11033,7 @@ fn session_message(
                 fields.push(session_message_total_training_effect_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10175,6 +11046,7 @@ fn session_message(
                 fields.push(session_message_first_lap_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10187,6 +11059,7 @@ fn session_message(
                 fields.push(session_message_num_laps_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10199,6 +11072,7 @@ fn session_message(
                 fields.push(session_message_event_group_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10211,6 +11085,7 @@ fn session_message(
                 fields.push(session_message_trigger_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10224,6 +11099,7 @@ fn session_message(
                 fields.push(session_message_nec_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10237,6 +11113,7 @@ fn session_message(
                 fields.push(session_message_nec_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10250,6 +11127,7 @@ fn session_message(
                 fields.push(session_message_swc_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10263,6 +11141,7 @@ fn session_message(
                 fields.push(session_message_swc_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10276,6 +11155,7 @@ fn session_message(
                 fields.push(session_message_num_lengths_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10288,6 +11168,7 @@ fn session_message(
                 fields.push(session_message_normalized_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10300,6 +11181,7 @@ fn session_message(
                 fields.push(session_message_training_stress_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10312,6 +11194,7 @@ fn session_message(
                 fields.push(session_message_intensity_factor_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10324,6 +11207,7 @@ fn session_message(
                 fields.push(session_message_left_right_balance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10336,6 +11220,7 @@ fn session_message(
                 fields.push(session_message_avg_stroke_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10348,6 +11233,7 @@ fn session_message(
                 fields.push(session_message_avg_stroke_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10360,6 +11246,7 @@ fn session_message(
                 fields.push(session_message_swim_stroke_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10372,6 +11259,7 @@ fn session_message(
                 fields.push(session_message_pool_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10384,6 +11272,7 @@ fn session_message(
                 fields.push(session_message_threshold_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10396,6 +11285,7 @@ fn session_message(
                 fields.push(session_message_pool_length_unit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10409,6 +11299,7 @@ fn session_message(
                 fields.push(session_message_num_active_lengths_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10421,6 +11312,7 @@ fn session_message(
                 fields.push(session_message_total_work_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10436,6 +11328,7 @@ fn session_message(
                 fields.push(session_message_enhanced_avg_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -10451,6 +11344,7 @@ fn session_message(
                 fields.push(session_message_enhanced_max_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -10463,6 +11357,7 @@ fn session_message(
                 fields.push(session_message_gps_accuracy_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10475,6 +11370,7 @@ fn session_message(
                 fields.push(session_message_avg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10487,6 +11383,7 @@ fn session_message(
                 fields.push(session_message_avg_pos_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10499,6 +11396,7 @@ fn session_message(
                 fields.push(session_message_avg_neg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10511,6 +11409,7 @@ fn session_message(
                 fields.push(session_message_max_pos_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10523,6 +11422,7 @@ fn session_message(
                 fields.push(session_message_max_neg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10535,6 +11435,7 @@ fn session_message(
                 fields.push(session_message_avg_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10547,6 +11448,7 @@ fn session_message(
                 fields.push(session_message_max_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10559,6 +11461,7 @@ fn session_message(
                 fields.push(session_message_total_moving_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10571,6 +11474,7 @@ fn session_message(
                 fields.push(session_message_avg_pos_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10583,6 +11487,7 @@ fn session_message(
                 fields.push(session_message_avg_neg_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10595,6 +11500,7 @@ fn session_message(
                 fields.push(session_message_max_pos_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10607,6 +11513,7 @@ fn session_message(
                 fields.push(session_message_max_neg_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10619,6 +11526,7 @@ fn session_message(
                 fields.push(session_message_min_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10631,6 +11539,7 @@ fn session_message(
                 fields.push(session_message_time_in_hr_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10643,6 +11552,7 @@ fn session_message(
                 fields.push(session_message_time_in_speed_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10655,6 +11565,7 @@ fn session_message(
                 fields.push(session_message_time_in_cadence_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10667,6 +11578,7 @@ fn session_message(
                 fields.push(session_message_time_in_power_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10679,6 +11591,7 @@ fn session_message(
                 fields.push(session_message_avg_lap_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -10691,6 +11604,7 @@ fn session_message(
                 fields.push(session_message_best_lap_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10706,6 +11620,7 @@ fn session_message(
                 fields.push(session_message_enhanced_min_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -10718,6 +11633,7 @@ fn session_message(
                 fields.push(session_message_player_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10730,6 +11646,7 @@ fn session_message(
                 fields.push(session_message_opponent_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10742,6 +11659,7 @@ fn session_message(
                 fields.push(session_message_opponent_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10755,6 +11673,7 @@ fn session_message(
                 fields.push(session_message_stroke_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10768,6 +11687,7 @@ fn session_message(
                 fields.push(session_message_zone_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -10780,6 +11700,7 @@ fn session_message(
                 fields.push(session_message_max_ball_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10792,6 +11713,7 @@ fn session_message(
                 fields.push(session_message_avg_ball_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10804,6 +11726,7 @@ fn session_message(
                 fields.push(session_message_avg_vertical_oscillation_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10816,6 +11739,7 @@ fn session_message(
                 fields.push(session_message_avg_stance_time_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10828,6 +11752,7 @@ fn session_message(
                 fields.push(session_message_avg_stance_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10841,6 +11766,7 @@ fn session_message(
                 fields.push(session_message_avg_fractional_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -10854,6 +11780,7 @@ fn session_message(
                 fields.push(session_message_max_fractional_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -10867,6 +11794,7 @@ fn session_message(
                 fields.push(session_message_total_fractional_cycles_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -10880,6 +11808,7 @@ fn session_message(
                 fields.push(session_message_avg_total_hemoglobin_conc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10893,6 +11822,7 @@ fn session_message(
                 fields.push(session_message_min_total_hemoglobin_conc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10906,6 +11836,7 @@ fn session_message(
                 fields.push(session_message_max_total_hemoglobin_conc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -10919,6 +11850,7 @@ fn session_message(
                 fields.push(session_message_avg_saturated_hemoglobin_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10932,6 +11864,7 @@ fn session_message(
                 fields.push(session_message_min_saturated_hemoglobin_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10945,6 +11878,7 @@ fn session_message(
                 fields.push(session_message_max_saturated_hemoglobin_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -10957,6 +11891,7 @@ fn session_message(
                 fields.push(session_message_avg_left_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -10969,6 +11904,7 @@ fn session_message(
                 fields.push(session_message_avg_right_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -10981,6 +11917,7 @@ fn session_message(
                 fields.push(session_message_avg_left_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -10993,6 +11930,7 @@ fn session_message(
                 fields.push(session_message_avg_right_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -11005,6 +11943,7 @@ fn session_message(
                 fields.push(session_message_avg_combined_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -11017,6 +11956,7 @@ fn session_message(
                 fields.push(session_message_sport_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11030,6 +11970,7 @@ fn session_message(
                 fields.push(session_message_time_standing_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -11043,6 +11984,7 @@ fn session_message(
                 fields.push(session_message_stand_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11056,6 +11998,7 @@ fn session_message(
                 fields.push(session_message_avg_left_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11069,6 +12012,7 @@ fn session_message(
                 fields.push(session_message_avg_right_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11082,6 +12026,7 @@ fn session_message(
                 fields.push(session_message_avg_left_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -11095,6 +12040,7 @@ fn session_message(
                 fields.push(session_message_avg_left_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -11108,6 +12054,7 @@ fn session_message(
                 fields.push(session_message_avg_right_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -11121,6 +12068,7 @@ fn session_message(
                 fields.push(session_message_avg_right_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -11134,6 +12082,7 @@ fn session_message(
                 fields.push(session_message_avg_power_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11147,6 +12096,7 @@ fn session_message(
                 fields.push(session_message_max_power_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11160,6 +12110,7 @@ fn session_message(
                 fields.push(session_message_avg_cadence_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11173,6 +12124,7 @@ fn session_message(
                 fields.push(session_message_max_cadence_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11186,6 +12138,7 @@ fn session_message(
                 fields.push(session_message_enhanced_avg_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -11198,6 +12151,7 @@ fn session_message(
                 fields.push(session_message_enhanced_max_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -11210,6 +12164,7 @@ fn session_message(
                 fields.push(session_message_enhanced_avg_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -11222,6 +12177,7 @@ fn session_message(
                 fields.push(session_message_enhanced_min_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -11234,6 +12190,7 @@ fn session_message(
                 fields.push(session_message_enhanced_max_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -11247,6 +12204,7 @@ fn session_message(
                 fields.push(session_message_avg_lev_motor_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11260,6 +12218,7 @@ fn session_message(
                 fields.push(session_message_max_lev_motor_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11273,6 +12232,7 @@ fn session_message(
                 fields.push(session_message_lev_battery_consumption_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -11285,6 +12245,7 @@ fn session_message(
                 fields.push(session_message_avg_vertical_ratio_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -11297,6 +12258,7 @@ fn session_message(
                 fields.push(session_message_avg_stance_time_balance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -11309,6 +12271,7 @@ fn session_message(
                 fields.push(session_message_avg_step_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -11321,6 +12284,7 @@ fn session_message(
                 fields.push(session_message_total_anaerobic_training_effect_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -11333,6 +12297,7 @@ fn session_message(
                 fields.push(session_message_avg_vam_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -11345,6 +12310,7 @@ fn session_message(
                 fields.push(session_message_training_load_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     65536.000000,
@@ -11358,6 +12324,7 @@ fn session_message(
                 fields.push(session_message_total_grit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11371,6 +12338,7 @@ fn session_message(
                 fields.push(session_message_total_flow_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11383,6 +12351,7 @@ fn session_message(
                 fields.push(session_message_jump_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11396,6 +12365,7 @@ fn session_message(
                 fields.push(session_message_avg_grit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11409,6 +12379,7 @@ fn session_message(
                 fields.push(session_message_avg_flow_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11422,6 +12393,7 @@ fn session_message(
                 fields.push(session_message_total_fractional_ascent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -11435,6 +12407,7 @@ fn session_message(
                 fields.push(session_message_total_fractional_descent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -11447,6 +12420,7 @@ fn session_message(
                 fields.push(session_message_avg_core_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -11459,6 +12433,7 @@ fn session_message(
                 fields.push(session_message_min_core_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -11471,6 +12446,7 @@ fn session_message(
                 fields.push(session_message_max_core_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -11484,6 +12460,7 @@ fn session_message(
                 fields.push(session_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11497,6 +12474,7 @@ fn session_message(
                 fields.push(session_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -11513,6 +12491,7 @@ fn session_message(
 fn session_message_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11533,11 +12512,13 @@ fn session_message_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_event_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11558,11 +12539,13 @@ fn session_message_event_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_start_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11583,11 +12566,13 @@ fn session_message_start_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_start_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11608,11 +12593,13 @@ fn session_message_start_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_start_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11633,11 +12620,13 @@ fn session_message_start_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11658,11 +12647,13 @@ fn session_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11683,11 +12674,13 @@ fn session_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_elapsed_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11708,11 +12701,13 @@ fn session_message_total_elapsed_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_timer_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11733,11 +12728,13 @@ fn session_message_total_timer_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11758,11 +12755,13 @@ fn session_message_total_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11783,11 +12782,13 @@ fn session_message_total_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_strides_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11808,11 +12809,13 @@ fn session_message_total_strides_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_strokes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11833,11 +12836,13 @@ fn session_message_total_strokes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11858,11 +12863,13 @@ fn session_message_total_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_fat_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11883,11 +12890,13 @@ fn session_message_total_fat_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11908,11 +12917,13 @@ fn session_message_avg_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11933,11 +12944,13 @@ fn session_message_max_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11958,11 +12971,13 @@ fn session_message_avg_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_running_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -11983,11 +12998,13 @@ fn session_message_avg_running_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12008,11 +13025,13 @@ fn session_message_max_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_running_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12033,11 +13052,13 @@ fn session_message_max_running_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12058,11 +13079,13 @@ fn session_message_avg_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12083,11 +13106,13 @@ fn session_message_max_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_ascent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12108,11 +13133,13 @@ fn session_message_total_ascent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_descent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12133,11 +13160,13 @@ fn session_message_total_descent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_training_effect_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12158,11 +13187,13 @@ fn session_message_total_training_effect_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_first_lap_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12183,11 +13214,13 @@ fn session_message_first_lap_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_num_laps_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12208,11 +13241,13 @@ fn session_message_num_laps_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_event_group_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12233,11 +13268,13 @@ fn session_message_event_group_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_trigger_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12258,11 +13295,13 @@ fn session_message_trigger_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_nec_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12283,11 +13322,13 @@ fn session_message_nec_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_nec_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12308,11 +13349,13 @@ fn session_message_nec_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_swc_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12333,11 +13376,13 @@ fn session_message_swc_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_swc_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12358,11 +13403,13 @@ fn session_message_swc_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_num_lengths_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12383,11 +13430,13 @@ fn session_message_num_lengths_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_normalized_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12408,11 +13457,13 @@ fn session_message_normalized_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_training_stress_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12433,11 +13484,13 @@ fn session_message_training_stress_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_intensity_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12458,11 +13511,13 @@ fn session_message_intensity_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_left_right_balance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12483,11 +13538,13 @@ fn session_message_left_right_balance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_stroke_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12508,11 +13565,13 @@ fn session_message_avg_stroke_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_stroke_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12533,11 +13592,13 @@ fn session_message_avg_stroke_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_swim_stroke_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12558,11 +13619,13 @@ fn session_message_swim_stroke_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_pool_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12583,11 +13646,13 @@ fn session_message_pool_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_threshold_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12608,11 +13673,13 @@ fn session_message_threshold_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_pool_length_unit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12633,11 +13700,13 @@ fn session_message_pool_length_unit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_num_active_lengths_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12658,11 +13727,13 @@ fn session_message_num_active_lengths_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_work_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12683,11 +13754,13 @@ fn session_message_total_work_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_gps_accuracy_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12708,11 +13781,13 @@ fn session_message_gps_accuracy_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12733,11 +13808,13 @@ fn session_message_avg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_pos_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12758,11 +13835,13 @@ fn session_message_avg_pos_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_neg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12783,11 +13862,13 @@ fn session_message_avg_neg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_pos_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12808,11 +13889,13 @@ fn session_message_max_pos_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_neg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12833,11 +13916,13 @@ fn session_message_max_neg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12858,11 +13943,13 @@ fn session_message_avg_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12883,11 +13970,13 @@ fn session_message_max_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_moving_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12908,11 +13997,13 @@ fn session_message_total_moving_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_pos_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12933,11 +14024,13 @@ fn session_message_avg_pos_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_neg_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12958,11 +14051,13 @@ fn session_message_avg_neg_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_pos_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -12983,11 +14078,13 @@ fn session_message_max_pos_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_neg_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13008,11 +14105,13 @@ fn session_message_max_neg_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_min_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13033,11 +14132,13 @@ fn session_message_min_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_time_in_hr_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13058,11 +14159,13 @@ fn session_message_time_in_hr_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_time_in_speed_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13083,11 +14186,13 @@ fn session_message_time_in_speed_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_time_in_cadence_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13108,11 +14213,13 @@ fn session_message_time_in_cadence_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_time_in_power_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13133,11 +14240,13 @@ fn session_message_time_in_power_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_lap_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13158,11 +14267,13 @@ fn session_message_avg_lap_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_best_lap_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13183,11 +14294,13 @@ fn session_message_best_lap_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_player_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13208,11 +14321,13 @@ fn session_message_player_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_opponent_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13233,11 +14348,13 @@ fn session_message_opponent_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_opponent_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13258,11 +14375,13 @@ fn session_message_opponent_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_stroke_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13283,11 +14402,13 @@ fn session_message_stroke_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_zone_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13308,11 +14429,13 @@ fn session_message_zone_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_ball_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13333,11 +14456,13 @@ fn session_message_max_ball_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_ball_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13358,11 +14483,13 @@ fn session_message_avg_ball_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_vertical_oscillation_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13383,11 +14510,13 @@ fn session_message_avg_vertical_oscillation_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_stance_time_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13408,11 +14537,13 @@ fn session_message_avg_stance_time_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_stance_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13433,11 +14564,13 @@ fn session_message_avg_stance_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_fractional_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13458,11 +14591,13 @@ fn session_message_avg_fractional_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_fractional_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13483,11 +14618,13 @@ fn session_message_max_fractional_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_fractional_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13508,11 +14645,13 @@ fn session_message_total_fractional_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_total_hemoglobin_conc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13533,11 +14672,13 @@ fn session_message_avg_total_hemoglobin_conc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_min_total_hemoglobin_conc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13558,11 +14699,13 @@ fn session_message_min_total_hemoglobin_conc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_total_hemoglobin_conc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13583,11 +14726,13 @@ fn session_message_max_total_hemoglobin_conc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_saturated_hemoglobin_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13608,11 +14753,13 @@ fn session_message_avg_saturated_hemoglobin_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_min_saturated_hemoglobin_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13633,11 +14780,13 @@ fn session_message_min_saturated_hemoglobin_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_saturated_hemoglobin_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13658,11 +14807,13 @@ fn session_message_max_saturated_hemoglobin_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_left_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13683,11 +14834,13 @@ fn session_message_avg_left_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_right_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13708,11 +14861,13 @@ fn session_message_avg_right_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_left_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13733,11 +14888,13 @@ fn session_message_avg_left_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_right_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13758,11 +14915,13 @@ fn session_message_avg_right_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_combined_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13783,11 +14942,13 @@ fn session_message_avg_combined_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_sport_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13808,11 +14969,13 @@ fn session_message_sport_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_time_standing_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13833,11 +14996,13 @@ fn session_message_time_standing_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_stand_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13858,11 +15023,13 @@ fn session_message_stand_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_left_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13883,11 +15050,13 @@ fn session_message_avg_left_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_right_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13908,11 +15077,13 @@ fn session_message_avg_right_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_left_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13933,11 +15104,13 @@ fn session_message_avg_left_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_left_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13958,11 +15131,13 @@ fn session_message_avg_left_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_right_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -13983,11 +15158,13 @@ fn session_message_avg_right_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_right_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14008,11 +15185,13 @@ fn session_message_avg_right_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_power_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14033,11 +15212,13 @@ fn session_message_avg_power_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_power_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14058,11 +15239,13 @@ fn session_message_max_power_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_cadence_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14083,11 +15266,13 @@ fn session_message_avg_cadence_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_cadence_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14108,11 +15293,13 @@ fn session_message_max_cadence_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_enhanced_avg_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14133,11 +15320,13 @@ fn session_message_enhanced_avg_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_enhanced_max_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14158,11 +15347,13 @@ fn session_message_enhanced_max_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_enhanced_avg_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14183,11 +15374,13 @@ fn session_message_enhanced_avg_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_enhanced_min_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14208,11 +15401,13 @@ fn session_message_enhanced_min_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_enhanced_max_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14233,11 +15428,13 @@ fn session_message_enhanced_max_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_lev_motor_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14258,11 +15455,13 @@ fn session_message_avg_lev_motor_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_lev_motor_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14283,11 +15482,13 @@ fn session_message_max_lev_motor_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_lev_battery_consumption_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14308,11 +15509,13 @@ fn session_message_lev_battery_consumption_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_vertical_ratio_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14333,11 +15536,13 @@ fn session_message_avg_vertical_ratio_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_stance_time_balance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14358,11 +15563,13 @@ fn session_message_avg_stance_time_balance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_step_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14383,11 +15590,13 @@ fn session_message_avg_step_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_anaerobic_training_effect_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14408,11 +15617,13 @@ fn session_message_total_anaerobic_training_effect_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_vam_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14433,11 +15644,13 @@ fn session_message_avg_vam_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_training_load_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14458,11 +15671,13 @@ fn session_message_training_load_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_grit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14483,11 +15698,13 @@ fn session_message_total_grit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_flow_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14508,11 +15725,13 @@ fn session_message_total_flow_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_jump_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14533,11 +15752,13 @@ fn session_message_jump_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_grit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14558,11 +15779,13 @@ fn session_message_avg_grit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_flow_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14583,11 +15806,13 @@ fn session_message_avg_flow_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_fractional_ascent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14608,11 +15833,13 @@ fn session_message_total_fractional_ascent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_total_fractional_descent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14633,11 +15860,13 @@ fn session_message_total_fractional_descent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_avg_core_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14658,11 +15887,13 @@ fn session_message_avg_core_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_min_core_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14683,11 +15914,13 @@ fn session_message_min_core_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_max_core_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14708,11 +15941,13 @@ fn session_message_max_core_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14733,11 +15968,13 @@ fn session_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn session_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -14758,12 +15995,14 @@ fn session_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -14774,6 +16013,7 @@ fn lap_message(
                 fields.push(lap_message_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -14786,6 +16026,7 @@ fn lap_message(
                 fields.push(lap_message_event_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -14798,6 +16039,7 @@ fn lap_message(
                 fields.push(lap_message_start_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -14810,6 +16052,7 @@ fn lap_message(
                 fields.push(lap_message_start_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -14822,6 +16065,7 @@ fn lap_message(
                 fields.push(lap_message_start_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -14834,6 +16078,7 @@ fn lap_message(
                 fields.push(lap_message_end_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -14846,6 +16091,7 @@ fn lap_message(
                 fields.push(lap_message_end_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -14859,6 +16105,7 @@ fn lap_message(
                 fields.push(lap_message_total_elapsed_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -14872,6 +16119,7 @@ fn lap_message(
                 fields.push(lap_message_total_timer_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -14884,6 +16132,7 @@ fn lap_message(
                 fields.push(lap_message_total_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -14903,6 +16152,7 @@ fn lap_message(
                     fields.push(lap_message_total_strides_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -14920,6 +16170,7 @@ fn lap_message(
                     fields.push(lap_message_total_strides_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -14937,6 +16188,7 @@ fn lap_message(
                     fields.push(lap_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -14954,6 +16206,7 @@ fn lap_message(
                     fields.push(lap_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -14971,6 +16224,7 @@ fn lap_message(
                     fields.push(lap_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -14988,6 +16242,7 @@ fn lap_message(
                     fields.push(lap_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -14999,6 +16254,7 @@ fn lap_message(
                     fields.push(lap_message_total_cycles_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -15012,6 +16268,7 @@ fn lap_message(
                 fields.push(lap_message_total_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15025,6 +16282,7 @@ fn lap_message(
                 fields.push(lap_message_total_fat_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15040,6 +16298,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_avg_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15055,6 +16314,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_max_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15067,6 +16327,7 @@ fn lap_message(
                 fields.push(lap_message_avg_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15079,6 +16340,7 @@ fn lap_message(
                 fields.push(lap_message_max_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15099,6 +16361,7 @@ fn lap_message(
                     fields.push(lap_message_avg_running_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -15110,6 +16373,7 @@ fn lap_message(
                     fields.push(lap_message_avg_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -15130,6 +16394,7 @@ fn lap_message(
                     fields.push(lap_message_max_running_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -15141,6 +16406,7 @@ fn lap_message(
                     fields.push(lap_message_max_cadence_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -15155,6 +16421,7 @@ fn lap_message(
                 fields.push(lap_message_avg_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15167,6 +16434,7 @@ fn lap_message(
                 fields.push(lap_message_max_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15179,6 +16447,7 @@ fn lap_message(
                 fields.push(lap_message_total_ascent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15191,6 +16460,7 @@ fn lap_message(
                 fields.push(lap_message_total_descent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15203,6 +16473,7 @@ fn lap_message(
                 fields.push(lap_message_intensity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15215,6 +16486,7 @@ fn lap_message(
                 fields.push(lap_message_lap_trigger_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15227,6 +16499,7 @@ fn lap_message(
                 fields.push(lap_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15239,6 +16512,7 @@ fn lap_message(
                 fields.push(lap_message_event_group_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15252,6 +16526,7 @@ fn lap_message(
                 fields.push(lap_message_num_lengths_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15264,6 +16539,7 @@ fn lap_message(
                 fields.push(lap_message_normalized_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15276,6 +16552,7 @@ fn lap_message(
                 fields.push(lap_message_left_right_balance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15288,6 +16565,7 @@ fn lap_message(
                 fields.push(lap_message_first_length_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15300,6 +16578,7 @@ fn lap_message(
                 fields.push(lap_message_avg_stroke_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15312,6 +16591,7 @@ fn lap_message(
                 fields.push(lap_message_swim_stroke_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15324,6 +16604,7 @@ fn lap_message(
                 fields.push(lap_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15337,6 +16618,7 @@ fn lap_message(
                 fields.push(lap_message_num_active_lengths_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15349,6 +16631,7 @@ fn lap_message(
                 fields.push(lap_message_total_work_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15364,6 +16647,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_avg_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -15379,6 +16663,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_max_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -15391,6 +16676,7 @@ fn lap_message(
                 fields.push(lap_message_gps_accuracy_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15403,6 +16689,7 @@ fn lap_message(
                 fields.push(lap_message_avg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15415,6 +16702,7 @@ fn lap_message(
                 fields.push(lap_message_avg_pos_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15427,6 +16715,7 @@ fn lap_message(
                 fields.push(lap_message_avg_neg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15439,6 +16728,7 @@ fn lap_message(
                 fields.push(lap_message_max_pos_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15451,6 +16741,7 @@ fn lap_message(
                 fields.push(lap_message_max_neg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15463,6 +16754,7 @@ fn lap_message(
                 fields.push(lap_message_avg_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15475,6 +16767,7 @@ fn lap_message(
                 fields.push(lap_message_max_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15487,6 +16780,7 @@ fn lap_message(
                 fields.push(lap_message_total_moving_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15499,6 +16793,7 @@ fn lap_message(
                 fields.push(lap_message_avg_pos_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15511,6 +16806,7 @@ fn lap_message(
                 fields.push(lap_message_avg_neg_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15523,6 +16819,7 @@ fn lap_message(
                 fields.push(lap_message_max_pos_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15535,6 +16832,7 @@ fn lap_message(
                 fields.push(lap_message_max_neg_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15547,6 +16845,7 @@ fn lap_message(
                 fields.push(lap_message_time_in_hr_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15559,6 +16858,7 @@ fn lap_message(
                 fields.push(lap_message_time_in_speed_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15571,6 +16871,7 @@ fn lap_message(
                 fields.push(lap_message_time_in_cadence_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15583,6 +16884,7 @@ fn lap_message(
                 fields.push(lap_message_time_in_power_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15595,6 +16897,7 @@ fn lap_message(
                 fields.push(lap_message_repetition_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15610,6 +16913,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_min_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -15622,6 +16926,7 @@ fn lap_message(
                 fields.push(lap_message_min_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15634,6 +16939,7 @@ fn lap_message(
                 fields.push(lap_message_wkt_step_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15646,6 +16952,7 @@ fn lap_message(
                 fields.push(lap_message_opponent_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15659,6 +16966,7 @@ fn lap_message(
                 fields.push(lap_message_stroke_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15672,6 +16980,7 @@ fn lap_message(
                 fields.push(lap_message_zone_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15684,6 +16993,7 @@ fn lap_message(
                 fields.push(lap_message_avg_vertical_oscillation_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -15696,6 +17006,7 @@ fn lap_message(
                 fields.push(lap_message_avg_stance_time_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15708,6 +17019,7 @@ fn lap_message(
                 fields.push(lap_message_avg_stance_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -15721,6 +17033,7 @@ fn lap_message(
                 fields.push(lap_message_avg_fractional_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -15734,6 +17047,7 @@ fn lap_message(
                 fields.push(lap_message_max_fractional_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -15747,6 +17061,7 @@ fn lap_message(
                 fields.push(lap_message_total_fractional_cycles_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -15759,6 +17074,7 @@ fn lap_message(
                 fields.push(lap_message_player_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15772,6 +17088,7 @@ fn lap_message(
                 fields.push(lap_message_avg_total_hemoglobin_conc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15785,6 +17102,7 @@ fn lap_message(
                 fields.push(lap_message_min_total_hemoglobin_conc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15798,6 +17116,7 @@ fn lap_message(
                 fields.push(lap_message_max_total_hemoglobin_conc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -15811,6 +17130,7 @@ fn lap_message(
                 fields.push(lap_message_avg_saturated_hemoglobin_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -15824,6 +17144,7 @@ fn lap_message(
                 fields.push(lap_message_min_saturated_hemoglobin_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -15837,6 +17158,7 @@ fn lap_message(
                 fields.push(lap_message_max_saturated_hemoglobin_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -15849,6 +17171,7 @@ fn lap_message(
                 fields.push(lap_message_avg_left_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -15861,6 +17184,7 @@ fn lap_message(
                 fields.push(lap_message_avg_right_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -15873,6 +17197,7 @@ fn lap_message(
                 fields.push(lap_message_avg_left_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -15885,6 +17210,7 @@ fn lap_message(
                 fields.push(lap_message_avg_right_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -15897,6 +17223,7 @@ fn lap_message(
                 fields.push(lap_message_avg_combined_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -15910,6 +17237,7 @@ fn lap_message(
                 fields.push(lap_message_time_standing_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -15923,6 +17251,7 @@ fn lap_message(
                 fields.push(lap_message_stand_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15936,6 +17265,7 @@ fn lap_message(
                 fields.push(lap_message_avg_left_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15949,6 +17279,7 @@ fn lap_message(
                 fields.push(lap_message_avg_right_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -15962,6 +17293,7 @@ fn lap_message(
                 fields.push(lap_message_avg_left_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -15975,6 +17307,7 @@ fn lap_message(
                 fields.push(lap_message_avg_left_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -15988,6 +17321,7 @@ fn lap_message(
                 fields.push(lap_message_avg_right_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -16001,6 +17335,7 @@ fn lap_message(
                 fields.push(lap_message_avg_right_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -16014,6 +17349,7 @@ fn lap_message(
                 fields.push(lap_message_avg_power_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16027,6 +17363,7 @@ fn lap_message(
                 fields.push(lap_message_max_power_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16040,6 +17377,7 @@ fn lap_message(
                 fields.push(lap_message_avg_cadence_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16053,6 +17391,7 @@ fn lap_message(
                 fields.push(lap_message_max_cadence_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16065,6 +17404,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_avg_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -16077,6 +17417,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_max_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -16089,6 +17430,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_avg_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -16101,6 +17443,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_min_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -16113,6 +17456,7 @@ fn lap_message(
                 fields.push(lap_message_enhanced_max_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -16126,6 +17470,7 @@ fn lap_message(
                 fields.push(lap_message_avg_lev_motor_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16139,6 +17484,7 @@ fn lap_message(
                 fields.push(lap_message_max_lev_motor_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16152,6 +17498,7 @@ fn lap_message(
                 fields.push(lap_message_lev_battery_consumption_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -16164,6 +17511,7 @@ fn lap_message(
                 fields.push(lap_message_avg_vertical_ratio_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -16176,6 +17524,7 @@ fn lap_message(
                 fields.push(lap_message_avg_stance_time_balance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -16188,6 +17537,7 @@ fn lap_message(
                 fields.push(lap_message_avg_step_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -16200,6 +17550,7 @@ fn lap_message(
                 fields.push(lap_message_avg_vam_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -16213,6 +17564,7 @@ fn lap_message(
                 fields.push(lap_message_total_grit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16226,6 +17578,7 @@ fn lap_message(
                 fields.push(lap_message_total_flow_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16238,6 +17591,7 @@ fn lap_message(
                 fields.push(lap_message_jump_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16251,6 +17605,7 @@ fn lap_message(
                 fields.push(lap_message_avg_grit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16264,6 +17619,7 @@ fn lap_message(
                 fields.push(lap_message_avg_flow_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16277,6 +17633,7 @@ fn lap_message(
                 fields.push(lap_message_total_fractional_ascent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -16290,6 +17647,7 @@ fn lap_message(
                 fields.push(lap_message_total_fractional_descent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -16302,6 +17660,7 @@ fn lap_message(
                 fields.push(lap_message_avg_core_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -16314,6 +17673,7 @@ fn lap_message(
                 fields.push(lap_message_min_core_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -16326,6 +17686,7 @@ fn lap_message(
                 fields.push(lap_message_max_core_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -16339,6 +17700,7 @@ fn lap_message(
                 fields.push(lap_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16351,6 +17713,7 @@ fn lap_message(
                 fields.push(lap_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -16367,6 +17730,7 @@ fn lap_message(
 fn lap_message_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16387,11 +17751,13 @@ fn lap_message_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_event_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16412,11 +17778,13 @@ fn lap_message_event_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_start_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16437,11 +17805,13 @@ fn lap_message_start_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_start_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16462,11 +17832,13 @@ fn lap_message_start_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_start_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16487,11 +17859,13 @@ fn lap_message_start_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_end_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16512,11 +17886,13 @@ fn lap_message_end_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_end_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16537,11 +17913,13 @@ fn lap_message_end_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_elapsed_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16562,11 +17940,13 @@ fn lap_message_total_elapsed_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_timer_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16587,11 +17967,13 @@ fn lap_message_total_timer_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16612,11 +17994,13 @@ fn lap_message_total_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16637,11 +18021,13 @@ fn lap_message_total_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_strides_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16662,11 +18048,13 @@ fn lap_message_total_strides_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_strokes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16687,11 +18075,13 @@ fn lap_message_total_strokes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16712,11 +18102,13 @@ fn lap_message_total_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_fat_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16737,11 +18129,13 @@ fn lap_message_total_fat_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16762,11 +18156,13 @@ fn lap_message_avg_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16787,11 +18183,13 @@ fn lap_message_max_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16812,11 +18210,13 @@ fn lap_message_avg_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_running_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16837,11 +18237,13 @@ fn lap_message_avg_running_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16862,11 +18264,13 @@ fn lap_message_max_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_running_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16887,11 +18291,13 @@ fn lap_message_max_running_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16912,11 +18318,13 @@ fn lap_message_avg_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16937,11 +18345,13 @@ fn lap_message_max_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_ascent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16962,11 +18372,13 @@ fn lap_message_total_ascent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_descent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -16987,11 +18399,13 @@ fn lap_message_total_descent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_intensity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17012,11 +18426,13 @@ fn lap_message_intensity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_lap_trigger_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17037,11 +18453,13 @@ fn lap_message_lap_trigger_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17062,11 +18480,13 @@ fn lap_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_event_group_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17087,11 +18507,13 @@ fn lap_message_event_group_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_num_lengths_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17112,11 +18534,13 @@ fn lap_message_num_lengths_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_normalized_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17137,11 +18561,13 @@ fn lap_message_normalized_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_left_right_balance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17162,11 +18588,13 @@ fn lap_message_left_right_balance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_first_length_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17187,11 +18615,13 @@ fn lap_message_first_length_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_stroke_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17212,11 +18642,13 @@ fn lap_message_avg_stroke_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_swim_stroke_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17237,11 +18669,13 @@ fn lap_message_swim_stroke_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17262,11 +18696,13 @@ fn lap_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_num_active_lengths_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17287,11 +18723,13 @@ fn lap_message_num_active_lengths_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_work_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17312,11 +18750,13 @@ fn lap_message_total_work_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_gps_accuracy_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17337,11 +18777,13 @@ fn lap_message_gps_accuracy_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17362,11 +18804,13 @@ fn lap_message_avg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_pos_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17387,11 +18831,13 @@ fn lap_message_avg_pos_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_neg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17412,11 +18858,13 @@ fn lap_message_avg_neg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_pos_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17437,11 +18885,13 @@ fn lap_message_max_pos_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_neg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17462,11 +18912,13 @@ fn lap_message_max_neg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17487,11 +18939,13 @@ fn lap_message_avg_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17512,11 +18966,13 @@ fn lap_message_max_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_moving_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17537,11 +18993,13 @@ fn lap_message_total_moving_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_pos_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17562,11 +19020,13 @@ fn lap_message_avg_pos_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_neg_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17587,11 +19047,13 @@ fn lap_message_avg_neg_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_pos_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17612,11 +19074,13 @@ fn lap_message_max_pos_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_neg_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17637,11 +19101,13 @@ fn lap_message_max_neg_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_time_in_hr_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17662,11 +19128,13 @@ fn lap_message_time_in_hr_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_time_in_speed_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17687,11 +19155,13 @@ fn lap_message_time_in_speed_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_time_in_cadence_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17712,11 +19182,13 @@ fn lap_message_time_in_cadence_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_time_in_power_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17737,11 +19209,13 @@ fn lap_message_time_in_power_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_repetition_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17762,11 +19236,13 @@ fn lap_message_repetition_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_min_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17787,11 +19263,13 @@ fn lap_message_min_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_wkt_step_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17812,11 +19290,13 @@ fn lap_message_wkt_step_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_opponent_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17837,11 +19317,13 @@ fn lap_message_opponent_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_stroke_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17862,11 +19344,13 @@ fn lap_message_stroke_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_zone_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17887,11 +19371,13 @@ fn lap_message_zone_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_vertical_oscillation_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17912,11 +19398,13 @@ fn lap_message_avg_vertical_oscillation_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_stance_time_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17937,11 +19425,13 @@ fn lap_message_avg_stance_time_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_stance_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17962,11 +19452,13 @@ fn lap_message_avg_stance_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_fractional_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -17987,11 +19479,13 @@ fn lap_message_avg_fractional_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_fractional_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18012,11 +19506,13 @@ fn lap_message_max_fractional_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_fractional_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18037,11 +19533,13 @@ fn lap_message_total_fractional_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_player_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18062,11 +19560,13 @@ fn lap_message_player_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_total_hemoglobin_conc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18087,11 +19587,13 @@ fn lap_message_avg_total_hemoglobin_conc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_min_total_hemoglobin_conc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18112,11 +19614,13 @@ fn lap_message_min_total_hemoglobin_conc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_total_hemoglobin_conc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18137,11 +19641,13 @@ fn lap_message_max_total_hemoglobin_conc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_saturated_hemoglobin_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18162,11 +19668,13 @@ fn lap_message_avg_saturated_hemoglobin_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_min_saturated_hemoglobin_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18187,11 +19695,13 @@ fn lap_message_min_saturated_hemoglobin_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_saturated_hemoglobin_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18212,11 +19722,13 @@ fn lap_message_max_saturated_hemoglobin_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_left_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18237,11 +19749,13 @@ fn lap_message_avg_left_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_right_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18262,11 +19776,13 @@ fn lap_message_avg_right_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_left_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18287,11 +19803,13 @@ fn lap_message_avg_left_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_right_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18312,11 +19830,13 @@ fn lap_message_avg_right_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_combined_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18337,11 +19857,13 @@ fn lap_message_avg_combined_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_time_standing_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18362,11 +19884,13 @@ fn lap_message_time_standing_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_stand_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18387,11 +19911,13 @@ fn lap_message_stand_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_left_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18412,11 +19938,13 @@ fn lap_message_avg_left_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_right_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18437,11 +19965,13 @@ fn lap_message_avg_right_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_left_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18462,11 +19992,13 @@ fn lap_message_avg_left_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_left_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18487,11 +20019,13 @@ fn lap_message_avg_left_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_right_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18512,11 +20046,13 @@ fn lap_message_avg_right_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_right_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18537,11 +20073,13 @@ fn lap_message_avg_right_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_power_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18562,11 +20100,13 @@ fn lap_message_avg_power_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_power_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18587,11 +20127,13 @@ fn lap_message_max_power_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_cadence_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18612,11 +20154,13 @@ fn lap_message_avg_cadence_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_cadence_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18637,11 +20181,13 @@ fn lap_message_max_cadence_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_enhanced_avg_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18662,11 +20208,13 @@ fn lap_message_enhanced_avg_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_enhanced_max_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18687,11 +20235,13 @@ fn lap_message_enhanced_max_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_enhanced_avg_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18712,11 +20262,13 @@ fn lap_message_enhanced_avg_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_enhanced_min_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18737,11 +20289,13 @@ fn lap_message_enhanced_min_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_enhanced_max_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18762,11 +20316,13 @@ fn lap_message_enhanced_max_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_lev_motor_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18787,11 +20343,13 @@ fn lap_message_avg_lev_motor_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_lev_motor_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18812,11 +20370,13 @@ fn lap_message_max_lev_motor_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_lev_battery_consumption_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18837,11 +20397,13 @@ fn lap_message_lev_battery_consumption_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_vertical_ratio_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18862,11 +20424,13 @@ fn lap_message_avg_vertical_ratio_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_stance_time_balance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18887,11 +20451,13 @@ fn lap_message_avg_stance_time_balance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_step_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18912,11 +20478,13 @@ fn lap_message_avg_step_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_vam_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18937,11 +20505,13 @@ fn lap_message_avg_vam_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_grit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18962,11 +20532,13 @@ fn lap_message_total_grit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_flow_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -18987,11 +20559,13 @@ fn lap_message_total_flow_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_jump_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19012,11 +20586,13 @@ fn lap_message_jump_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_grit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19037,11 +20613,13 @@ fn lap_message_avg_grit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_flow_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19062,11 +20640,13 @@ fn lap_message_avg_flow_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_fractional_ascent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19087,11 +20667,13 @@ fn lap_message_total_fractional_ascent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_total_fractional_descent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19112,11 +20694,13 @@ fn lap_message_total_fractional_descent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_avg_core_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19137,11 +20721,13 @@ fn lap_message_avg_core_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_min_core_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19162,11 +20748,13 @@ fn lap_message_min_core_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_max_core_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19187,11 +20775,13 @@ fn lap_message_max_core_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19212,11 +20802,13 @@ fn lap_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn lap_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19237,12 +20829,14 @@ fn lap_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -19253,6 +20847,7 @@ fn length_message(
                 fields.push(length_message_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19265,6 +20860,7 @@ fn length_message(
                 fields.push(length_message_event_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19277,6 +20873,7 @@ fn length_message(
                 fields.push(length_message_start_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19289,6 +20886,7 @@ fn length_message(
                 fields.push(length_message_total_elapsed_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -19301,6 +20899,7 @@ fn length_message(
                 fields.push(length_message_total_timer_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -19313,6 +20912,7 @@ fn length_message(
                 fields.push(length_message_total_strokes_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19325,6 +20925,7 @@ fn length_message(
                 fields.push(length_message_avg_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -19337,6 +20938,7 @@ fn length_message(
                 fields.push(length_message_swim_stroke_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19349,6 +20951,7 @@ fn length_message(
                 fields.push(length_message_avg_swimming_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19361,6 +20964,7 @@ fn length_message(
                 fields.push(length_message_event_group_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19373,6 +20977,7 @@ fn length_message(
                 fields.push(length_message_total_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19385,6 +20990,7 @@ fn length_message(
                 fields.push(length_message_length_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19397,6 +21003,7 @@ fn length_message(
                 fields.push(length_message_player_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19409,6 +21016,7 @@ fn length_message(
                 fields.push(length_message_opponent_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19422,6 +21030,7 @@ fn length_message(
                 fields.push(length_message_stroke_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19435,6 +21044,7 @@ fn length_message(
                 fields.push(length_message_zone_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19447,6 +21057,7 @@ fn length_message(
                 fields.push(length_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19459,6 +21070,7 @@ fn length_message(
                 fields.push(length_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19475,6 +21087,7 @@ fn length_message(
 fn length_message_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19495,11 +21108,13 @@ fn length_message_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_event_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19520,11 +21135,13 @@ fn length_message_event_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_start_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19545,11 +21162,13 @@ fn length_message_start_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_total_elapsed_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19570,11 +21189,13 @@ fn length_message_total_elapsed_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_total_timer_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19595,11 +21216,13 @@ fn length_message_total_timer_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_total_strokes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19620,11 +21243,13 @@ fn length_message_total_strokes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_avg_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19645,11 +21270,13 @@ fn length_message_avg_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_swim_stroke_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19670,11 +21297,13 @@ fn length_message_swim_stroke_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_avg_swimming_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19695,11 +21324,13 @@ fn length_message_avg_swimming_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_event_group_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19720,11 +21351,13 @@ fn length_message_event_group_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_total_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19745,11 +21378,13 @@ fn length_message_total_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_length_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19770,11 +21405,13 @@ fn length_message_length_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_player_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19795,11 +21432,13 @@ fn length_message_player_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_opponent_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19820,11 +21459,13 @@ fn length_message_opponent_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_stroke_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19845,11 +21486,13 @@ fn length_message_stroke_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_zone_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19870,11 +21513,13 @@ fn length_message_zone_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19895,11 +21540,13 @@ fn length_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn length_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -19920,12 +21567,14 @@ fn length_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -19936,6 +21585,7 @@ fn record_message(
                 fields.push(record_message_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19948,6 +21598,7 @@ fn record_message(
                 fields.push(record_message_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19963,6 +21614,7 @@ fn record_message(
                 fields.push(record_message_enhanced_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -19975,6 +21627,7 @@ fn record_message(
                 fields.push(record_message_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19987,6 +21640,7 @@ fn record_message(
                 fields.push(record_message_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -19999,6 +21653,7 @@ fn record_message(
                 fields.push(record_message_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20014,6 +21669,7 @@ fn record_message(
                 fields.push(record_message_enhanced_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -20026,6 +21682,7 @@ fn record_message(
                 fields.push(record_message_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20046,6 +21703,7 @@ fn record_message(
                 fields.push(record_message_enhanced_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20057,6 +21715,7 @@ fn record_message(
                 fields.push(record_message_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     true,
                     16.000000,
@@ -20069,6 +21728,7 @@ fn record_message(
                 fields.push(record_message_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20082,6 +21742,7 @@ fn record_message(
                 fields.push(record_message_resistance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20094,6 +21755,7 @@ fn record_message(
                 fields.push(record_message_time_from_course_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -20106,6 +21768,7 @@ fn record_message(
                 fields.push(record_message_cycle_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20118,6 +21781,7 @@ fn record_message(
                 fields.push(record_message_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20131,6 +21795,7 @@ fn record_message(
                 fields.push(record_message_speed_1s_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     16.000000,
@@ -20146,6 +21811,7 @@ fn record_message(
                 fields.push(record_message_total_cycles_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     true,
                     1.000000,
@@ -20158,6 +21824,7 @@ fn record_message(
                 fields.push(record_message_total_cycles_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20175,6 +21842,7 @@ fn record_message(
                 fields.push(record_message_accumulated_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     true,
                     1.000000,
@@ -20187,6 +21855,7 @@ fn record_message(
                 fields.push(record_message_accumulated_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20199,6 +21868,7 @@ fn record_message(
                 fields.push(record_message_left_right_balance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20211,6 +21881,7 @@ fn record_message(
                 fields.push(record_message_gps_accuracy_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20223,6 +21894,7 @@ fn record_message(
                 fields.push(record_message_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -20235,6 +21907,7 @@ fn record_message(
                 fields.push(record_message_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20247,6 +21920,7 @@ fn record_message(
                 fields.push(record_message_vertical_oscillation_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -20259,6 +21933,7 @@ fn record_message(
                 fields.push(record_message_stance_time_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20271,6 +21946,7 @@ fn record_message(
                 fields.push(record_message_stance_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -20283,6 +21959,7 @@ fn record_message(
                 fields.push(record_message_activity_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20295,6 +21972,7 @@ fn record_message(
                 fields.push(record_message_left_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -20307,6 +21985,7 @@ fn record_message(
                 fields.push(record_message_right_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -20319,6 +21998,7 @@ fn record_message(
                 fields.push(record_message_left_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -20331,6 +22011,7 @@ fn record_message(
                 fields.push(record_message_right_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -20343,6 +22024,7 @@ fn record_message(
                 fields.push(record_message_combined_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -20355,6 +22037,7 @@ fn record_message(
                 fields.push(record_message_time128_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -20367,6 +22050,7 @@ fn record_message(
                 fields.push(record_message_stroke_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20379,6 +22063,7 @@ fn record_message(
                 fields.push(record_message_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20391,6 +22076,7 @@ fn record_message(
                 fields.push(record_message_ball_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20404,6 +22090,7 @@ fn record_message(
                 fields.push(record_message_cadence256_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     256.000000,
@@ -20416,6 +22103,7 @@ fn record_message(
                 fields.push(record_message_fractional_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -20429,6 +22117,7 @@ fn record_message(
                 fields.push(record_message_total_hemoglobin_conc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20442,6 +22131,7 @@ fn record_message(
                 fields.push(record_message_total_hemoglobin_conc_min_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20455,6 +22145,7 @@ fn record_message(
                 fields.push(record_message_total_hemoglobin_conc_max_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20468,6 +22159,7 @@ fn record_message(
                 fields.push(record_message_saturated_hemoglobin_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -20481,6 +22173,7 @@ fn record_message(
                 fields.push(record_message_saturated_hemoglobin_percent_min_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -20494,6 +22187,7 @@ fn record_message(
                 fields.push(record_message_saturated_hemoglobin_percent_max_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -20506,6 +22200,7 @@ fn record_message(
                 fields.push(record_message_device_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20519,6 +22214,7 @@ fn record_message(
                 fields.push(record_message_left_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20532,6 +22228,7 @@ fn record_message(
                 fields.push(record_message_right_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20545,6 +22242,7 @@ fn record_message(
                 fields.push(record_message_left_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -20558,6 +22256,7 @@ fn record_message(
                 fields.push(record_message_left_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -20571,6 +22270,7 @@ fn record_message(
                 fields.push(record_message_right_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -20584,6 +22284,7 @@ fn record_message(
                 fields.push(record_message_right_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -20596,6 +22297,7 @@ fn record_message(
                 fields.push(record_message_enhanced_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -20608,6 +22310,7 @@ fn record_message(
                 fields.push(record_message_enhanced_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -20621,6 +22324,7 @@ fn record_message(
                 fields.push(record_message_battery_soc_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -20634,6 +22338,7 @@ fn record_message(
                 fields.push(record_message_motor_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20646,6 +22351,7 @@ fn record_message(
                 fields.push(record_message_vertical_ratio_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20658,6 +22364,7 @@ fn record_message(
                 fields.push(record_message_stance_time_balance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20670,6 +22377,7 @@ fn record_message(
                 fields.push(record_message_step_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -20683,6 +22391,7 @@ fn record_message(
                 fields.push(record_message_absolute_pressure_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20696,6 +22405,7 @@ fn record_message(
                 fields.push(record_message_depth_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -20709,6 +22419,7 @@ fn record_message(
                 fields.push(record_message_next_stop_depth_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -20721,6 +22432,7 @@ fn record_message(
                 fields.push(record_message_next_stop_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20733,6 +22445,7 @@ fn record_message(
                 fields.push(record_message_time_to_surface_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20745,6 +22458,7 @@ fn record_message(
                 fields.push(record_message_ndl_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20757,6 +22471,7 @@ fn record_message(
                 fields.push(record_message_cns_load_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20769,6 +22484,7 @@ fn record_message(
                 fields.push(record_message_n2_load_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20782,6 +22498,7 @@ fn record_message(
                 fields.push(record_message_grit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20795,6 +22512,7 @@ fn record_message(
                 fields.push(record_message_flow_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20807,6 +22525,7 @@ fn record_message(
                 fields.push(record_message_ebike_travel_range_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20819,6 +22538,7 @@ fn record_message(
                 fields.push(record_message_ebike_battery_level_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20831,6 +22551,7 @@ fn record_message(
                 fields.push(record_message_ebike_assist_mode_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20843,6 +22564,7 @@ fn record_message(
                 fields.push(record_message_ebike_assist_level_percent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20855,6 +22577,7 @@ fn record_message(
                 fields.push(record_message_core_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -20867,6 +22590,7 @@ fn record_message(
                 fields.push(record_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -20883,6 +22607,7 @@ fn record_message(
 fn record_message_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -20903,11 +22628,13 @@ fn record_message_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -20928,11 +22655,13 @@ fn record_message_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -20953,11 +22682,13 @@ fn record_message_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -20978,11 +22709,13 @@ fn record_message_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21003,11 +22736,13 @@ fn record_message_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21028,11 +22763,13 @@ fn record_message_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21053,11 +22790,13 @@ fn record_message_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_resistance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21078,11 +22817,13 @@ fn record_message_resistance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_time_from_course_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21103,11 +22844,13 @@ fn record_message_time_from_course_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_cycle_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21128,11 +22871,13 @@ fn record_message_cycle_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21153,11 +22898,13 @@ fn record_message_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_speed_1s_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21178,11 +22925,13 @@ fn record_message_speed_1s_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_total_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21203,11 +22952,13 @@ fn record_message_total_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_accumulated_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21228,11 +22979,13 @@ fn record_message_accumulated_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_left_right_balance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21253,11 +23006,13 @@ fn record_message_left_right_balance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_gps_accuracy_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21278,11 +23033,13 @@ fn record_message_gps_accuracy_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21303,11 +23060,13 @@ fn record_message_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21328,11 +23087,13 @@ fn record_message_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_vertical_oscillation_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21353,11 +23114,13 @@ fn record_message_vertical_oscillation_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_stance_time_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21378,11 +23141,13 @@ fn record_message_stance_time_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_stance_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21403,11 +23168,13 @@ fn record_message_stance_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_activity_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21428,11 +23195,13 @@ fn record_message_activity_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_left_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21453,11 +23222,13 @@ fn record_message_left_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_right_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21478,11 +23249,13 @@ fn record_message_right_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_left_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21503,11 +23276,13 @@ fn record_message_left_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_right_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21528,11 +23303,13 @@ fn record_message_right_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_combined_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21553,11 +23330,13 @@ fn record_message_combined_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_time128_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21578,11 +23357,13 @@ fn record_message_time128_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_stroke_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21603,11 +23384,13 @@ fn record_message_stroke_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21628,11 +23411,13 @@ fn record_message_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_ball_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21653,11 +23438,13 @@ fn record_message_ball_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_cadence256_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21678,11 +23465,13 @@ fn record_message_cadence256_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_fractional_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21703,11 +23492,13 @@ fn record_message_fractional_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_total_hemoglobin_conc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21728,11 +23519,13 @@ fn record_message_total_hemoglobin_conc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_total_hemoglobin_conc_min_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21753,11 +23546,13 @@ fn record_message_total_hemoglobin_conc_min_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_total_hemoglobin_conc_max_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21778,11 +23573,13 @@ fn record_message_total_hemoglobin_conc_max_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_saturated_hemoglobin_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21803,11 +23600,13 @@ fn record_message_saturated_hemoglobin_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_saturated_hemoglobin_percent_min_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21828,11 +23627,13 @@ fn record_message_saturated_hemoglobin_percent_min_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_saturated_hemoglobin_percent_max_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21853,11 +23654,13 @@ fn record_message_saturated_hemoglobin_percent_max_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_device_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21878,11 +23681,13 @@ fn record_message_device_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_left_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21903,11 +23708,13 @@ fn record_message_left_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_right_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21928,11 +23735,13 @@ fn record_message_right_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_left_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21953,11 +23762,13 @@ fn record_message_left_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_left_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -21978,11 +23789,13 @@ fn record_message_left_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_right_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22003,11 +23816,13 @@ fn record_message_right_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_right_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22028,11 +23843,13 @@ fn record_message_right_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_enhanced_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22053,11 +23870,13 @@ fn record_message_enhanced_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_enhanced_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22078,11 +23897,13 @@ fn record_message_enhanced_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_battery_soc_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22103,11 +23924,13 @@ fn record_message_battery_soc_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_motor_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22128,11 +23951,13 @@ fn record_message_motor_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_vertical_ratio_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22153,11 +23978,13 @@ fn record_message_vertical_ratio_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_stance_time_balance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22178,11 +24005,13 @@ fn record_message_stance_time_balance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_step_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22203,11 +24032,13 @@ fn record_message_step_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_absolute_pressure_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22228,11 +24059,13 @@ fn record_message_absolute_pressure_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_depth_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22253,11 +24086,13 @@ fn record_message_depth_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_next_stop_depth_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22278,11 +24113,13 @@ fn record_message_next_stop_depth_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_next_stop_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22303,11 +24140,13 @@ fn record_message_next_stop_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_time_to_surface_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22328,11 +24167,13 @@ fn record_message_time_to_surface_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_ndl_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22353,11 +24194,13 @@ fn record_message_ndl_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_cns_load_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22378,11 +24221,13 @@ fn record_message_cns_load_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_n2_load_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22403,11 +24248,13 @@ fn record_message_n2_load_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_grit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22428,11 +24275,13 @@ fn record_message_grit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_flow_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22453,11 +24302,13 @@ fn record_message_flow_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_ebike_travel_range_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22478,11 +24329,13 @@ fn record_message_ebike_travel_range_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_ebike_battery_level_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22503,11 +24356,13 @@ fn record_message_ebike_battery_level_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_ebike_assist_mode_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22528,11 +24383,13 @@ fn record_message_ebike_assist_mode_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_ebike_assist_level_percent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22553,11 +24410,13 @@ fn record_message_ebike_assist_level_percent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_core_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22578,11 +24437,13 @@ fn record_message_core_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn record_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -22603,12 +24464,14 @@ fn record_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -22619,6 +24482,7 @@ fn event_message(
                 fields.push(event_message_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -22631,6 +24495,7 @@ fn event_message(
                 fields.push(event_message_event_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -22653,6 +24518,7 @@ fn event_message(
                     fields.push(event_message_timer_trigger_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22670,6 +24536,7 @@ fn event_message(
                     fields.push(event_message_course_point_index_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22687,6 +24554,7 @@ fn event_message(
                     fields.push(event_message_battery_level_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -22704,6 +24572,7 @@ fn event_message(
                     fields.push(event_message_virtual_partner_speed_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -22721,6 +24590,7 @@ fn event_message(
                     fields.push(event_message_hr_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22738,6 +24608,7 @@ fn event_message(
                     fields.push(event_message_hr_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22755,6 +24626,7 @@ fn event_message(
                     fields.push(event_message_speed_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -22772,6 +24644,7 @@ fn event_message(
                     fields.push(event_message_speed_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -22789,6 +24662,7 @@ fn event_message(
                     fields.push(event_message_cad_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22806,6 +24680,7 @@ fn event_message(
                     fields.push(event_message_cad_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22823,6 +24698,7 @@ fn event_message(
                     fields.push(event_message_power_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22840,6 +24716,7 @@ fn event_message(
                     fields.push(event_message_power_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22857,6 +24734,7 @@ fn event_message(
                     fields.push(event_message_time_duration_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -22874,6 +24752,7 @@ fn event_message(
                     fields.push(event_message_distance_duration_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         100.000000,
@@ -22891,6 +24770,7 @@ fn event_message(
                     fields.push(event_message_calorie_duration_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22908,6 +24788,7 @@ fn event_message(
                     fields.push(event_message_fitness_equipment_state_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22925,6 +24806,7 @@ fn event_message(
                     fields.push(event_message_sport_point_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22942,6 +24824,7 @@ fn event_message(
                     fields.push(event_message_gear_change_data_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22959,6 +24842,7 @@ fn event_message(
                     fields.push(event_message_gear_change_data_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22976,6 +24860,7 @@ fn event_message(
                     fields.push(event_message_rider_position_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -22993,6 +24878,7 @@ fn event_message(
                     fields.push(event_message_comm_timeout_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23010,6 +24896,7 @@ fn event_message(
                     fields.push(event_message_radar_threat_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23021,6 +24908,7 @@ fn event_message(
                     fields.push(event_message_data_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23041,6 +24929,7 @@ fn event_message(
                     fields.push(event_message_timer_trigger_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23058,6 +24947,7 @@ fn event_message(
                     fields.push(event_message_course_point_index_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23075,6 +24965,7 @@ fn event_message(
                     fields.push(event_message_battery_level_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -23092,6 +24983,7 @@ fn event_message(
                     fields.push(event_message_virtual_partner_speed_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -23109,6 +25001,7 @@ fn event_message(
                     fields.push(event_message_hr_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23126,6 +25019,7 @@ fn event_message(
                     fields.push(event_message_hr_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23143,6 +25037,7 @@ fn event_message(
                     fields.push(event_message_speed_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -23160,6 +25055,7 @@ fn event_message(
                     fields.push(event_message_speed_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -23177,6 +25073,7 @@ fn event_message(
                     fields.push(event_message_cad_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23194,6 +25091,7 @@ fn event_message(
                     fields.push(event_message_cad_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23211,6 +25109,7 @@ fn event_message(
                     fields.push(event_message_power_high_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23228,6 +25127,7 @@ fn event_message(
                     fields.push(event_message_power_low_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23245,6 +25145,7 @@ fn event_message(
                     fields.push(event_message_time_duration_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -23262,6 +25163,7 @@ fn event_message(
                     fields.push(event_message_distance_duration_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         100.000000,
@@ -23279,6 +25181,7 @@ fn event_message(
                     fields.push(event_message_calorie_duration_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23296,6 +25199,7 @@ fn event_message(
                     fields.push(event_message_fitness_equipment_state_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23313,6 +25217,7 @@ fn event_message(
                     fields.push(event_message_sport_point_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23330,6 +25235,7 @@ fn event_message(
                     fields.push(event_message_gear_change_data_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23347,6 +25253,7 @@ fn event_message(
                     fields.push(event_message_gear_change_data_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23364,6 +25271,7 @@ fn event_message(
                     fields.push(event_message_rider_position_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23381,6 +25289,7 @@ fn event_message(
                     fields.push(event_message_comm_timeout_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23398,6 +25307,7 @@ fn event_message(
                     fields.push(event_message_radar_threat_alert_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23409,6 +25319,7 @@ fn event_message(
                     fields.push(event_message_data_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -23422,6 +25333,7 @@ fn event_message(
                 fields.push(event_message_event_group_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23435,6 +25347,7 @@ fn event_message(
                 fields.push(event_message_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23448,6 +25361,7 @@ fn event_message(
                 fields.push(event_message_opponent_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23461,6 +25375,7 @@ fn event_message(
                 fields.push(event_message_front_gear_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23474,6 +25389,7 @@ fn event_message(
                 fields.push(event_message_front_gear_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23487,6 +25403,7 @@ fn event_message(
                 fields.push(event_message_rear_gear_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23500,6 +25417,7 @@ fn event_message(
                 fields.push(event_message_rear_gear_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23512,6 +25430,7 @@ fn event_message(
                 fields.push(event_message_device_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23525,6 +25444,7 @@ fn event_message(
                 fields.push(event_message_radar_threat_level_max_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23538,6 +25458,7 @@ fn event_message(
                 fields.push(event_message_radar_threat_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23551,6 +25472,7 @@ fn event_message(
                 fields.push(event_message_radar_threat_avg_approach_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -23564,6 +25486,7 @@ fn event_message(
                 fields.push(event_message_radar_threat_max_approach_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -23576,6 +25499,7 @@ fn event_message(
                 fields.push(event_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -23592,6 +25516,7 @@ fn event_message(
 fn event_message_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23612,11 +25537,13 @@ fn event_message_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_event_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23637,11 +25564,13 @@ fn event_message_event_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_data_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23662,11 +25591,13 @@ fn event_message_data_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_timer_trigger_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23687,11 +25618,13 @@ fn event_message_timer_trigger_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_course_point_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23712,11 +25645,13 @@ fn event_message_course_point_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_battery_level_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23737,11 +25672,13 @@ fn event_message_battery_level_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_virtual_partner_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23762,11 +25699,13 @@ fn event_message_virtual_partner_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_hr_high_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23787,11 +25726,13 @@ fn event_message_hr_high_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_hr_low_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23812,11 +25753,13 @@ fn event_message_hr_low_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_speed_high_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23837,11 +25780,13 @@ fn event_message_speed_high_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_speed_low_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23862,11 +25807,13 @@ fn event_message_speed_low_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_cad_high_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23887,11 +25834,13 @@ fn event_message_cad_high_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_cad_low_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23912,11 +25861,13 @@ fn event_message_cad_low_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_power_high_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23937,11 +25888,13 @@ fn event_message_power_high_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_power_low_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23962,11 +25915,13 @@ fn event_message_power_low_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_time_duration_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -23987,11 +25942,13 @@ fn event_message_time_duration_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_distance_duration_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24012,11 +25969,13 @@ fn event_message_distance_duration_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_calorie_duration_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24037,11 +25996,13 @@ fn event_message_calorie_duration_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_fitness_equipment_state_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24062,11 +26023,13 @@ fn event_message_fitness_equipment_state_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_sport_point_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24087,11 +26050,13 @@ fn event_message_sport_point_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_gear_change_data_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24112,11 +26077,13 @@ fn event_message_gear_change_data_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_rider_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24137,11 +26104,13 @@ fn event_message_rider_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_comm_timeout_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24162,11 +26131,13 @@ fn event_message_comm_timeout_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_radar_threat_alert_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24187,11 +26158,13 @@ fn event_message_radar_threat_alert_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_event_group_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24212,11 +26185,13 @@ fn event_message_event_group_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24237,11 +26212,13 @@ fn event_message_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_opponent_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24262,11 +26239,13 @@ fn event_message_opponent_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_front_gear_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24287,11 +26266,13 @@ fn event_message_front_gear_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_front_gear_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24312,11 +26293,13 @@ fn event_message_front_gear_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_rear_gear_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24337,11 +26320,13 @@ fn event_message_rear_gear_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_rear_gear_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24362,11 +26347,13 @@ fn event_message_rear_gear_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_device_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24387,11 +26374,13 @@ fn event_message_device_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_radar_threat_level_max_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24412,11 +26401,13 @@ fn event_message_radar_threat_level_max_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_radar_threat_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24437,11 +26428,13 @@ fn event_message_radar_threat_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_radar_threat_avg_approach_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24462,11 +26455,13 @@ fn event_message_radar_threat_avg_approach_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_radar_threat_max_approach_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24487,11 +26482,13 @@ fn event_message_radar_threat_max_approach_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn event_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24512,12 +26509,14 @@ fn event_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -24528,6 +26527,7 @@ fn device_info_message(
                 fields.push(device_info_message_device_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24547,6 +26547,7 @@ fn device_info_message(
                     fields.push(device_info_message_antplus_device_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24564,6 +26565,7 @@ fn device_info_message(
                     fields.push(device_info_message_ant_device_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24575,6 +26577,7 @@ fn device_info_message(
                     fields.push(device_info_message_device_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24588,6 +26591,7 @@ fn device_info_message(
                 fields.push(device_info_message_manufacturer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24600,6 +26604,7 @@ fn device_info_message(
                 fields.push(device_info_message_serial_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24619,6 +26624,7 @@ fn device_info_message(
                     fields.push(device_info_message_favero_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24636,6 +26642,7 @@ fn device_info_message(
                     fields.push(device_info_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24653,6 +26660,7 @@ fn device_info_message(
                     fields.push(device_info_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24670,6 +26678,7 @@ fn device_info_message(
                     fields.push(device_info_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24687,6 +26696,7 @@ fn device_info_message(
                     fields.push(device_info_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24698,6 +26708,7 @@ fn device_info_message(
                     fields.push(device_info_message_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -24711,6 +26722,7 @@ fn device_info_message(
                 fields.push(device_info_message_software_version_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -24723,6 +26735,7 @@ fn device_info_message(
                 fields.push(device_info_message_hardware_version_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24736,6 +26749,7 @@ fn device_info_message(
                 fields.push(device_info_message_cum_operating_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24748,6 +26762,7 @@ fn device_info_message(
                 fields.push(device_info_message_battery_voltage_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     256.000000,
@@ -24760,6 +26775,7 @@ fn device_info_message(
                 fields.push(device_info_message_battery_status_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24773,6 +26789,7 @@ fn device_info_message(
                 fields.push(device_info_message_sensor_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24786,6 +26803,7 @@ fn device_info_message(
                 fields.push(device_info_message_descriptor_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24798,6 +26816,7 @@ fn device_info_message(
                 fields.push(device_info_message_ant_transmission_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24810,6 +26829,7 @@ fn device_info_message(
                 fields.push(device_info_message_ant_device_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24822,6 +26842,7 @@ fn device_info_message(
                 fields.push(device_info_message_ant_network_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24834,6 +26855,7 @@ fn device_info_message(
                 fields.push(device_info_message_source_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24847,6 +26869,7 @@ fn device_info_message(
                 fields.push(device_info_message_product_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24859,6 +26882,7 @@ fn device_info_message(
                 fields.push(device_info_message_battery_level_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24871,6 +26895,7 @@ fn device_info_message(
                 fields.push(device_info_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -24887,6 +26912,7 @@ fn device_info_message(
 fn device_info_message_device_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24907,11 +26933,13 @@ fn device_info_message_device_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_device_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24932,11 +26960,13 @@ fn device_info_message_device_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_antplus_device_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24957,11 +26987,13 @@ fn device_info_message_antplus_device_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_ant_device_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -24982,11 +27014,13 @@ fn device_info_message_ant_device_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_manufacturer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25007,11 +27041,13 @@ fn device_info_message_manufacturer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_serial_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25032,11 +27068,13 @@ fn device_info_message_serial_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25057,11 +27095,13 @@ fn device_info_message_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_favero_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25082,11 +27122,13 @@ fn device_info_message_favero_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_garmin_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25107,11 +27149,13 @@ fn device_info_message_garmin_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_software_version_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25132,11 +27176,13 @@ fn device_info_message_software_version_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_hardware_version_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25157,11 +27203,13 @@ fn device_info_message_hardware_version_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_cum_operating_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25182,11 +27230,13 @@ fn device_info_message_cum_operating_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_battery_voltage_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25207,11 +27257,13 @@ fn device_info_message_battery_voltage_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_battery_status_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25232,11 +27284,13 @@ fn device_info_message_battery_status_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_sensor_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25257,11 +27311,13 @@ fn device_info_message_sensor_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_descriptor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25282,11 +27338,13 @@ fn device_info_message_descriptor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_ant_transmission_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25307,11 +27365,13 @@ fn device_info_message_ant_transmission_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_ant_device_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25332,11 +27392,13 @@ fn device_info_message_ant_device_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_ant_network_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25357,11 +27419,13 @@ fn device_info_message_ant_network_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_source_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25382,11 +27446,13 @@ fn device_info_message_source_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_product_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25407,11 +27473,13 @@ fn device_info_message_product_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_battery_level_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25432,11 +27500,13 @@ fn device_info_message_battery_level_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_info_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25457,12 +27527,14 @@ fn device_info_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_aux_battery_info_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -25473,6 +27545,7 @@ fn device_aux_battery_info_message(
                 fields.push(device_aux_battery_info_message_device_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25485,6 +27558,7 @@ fn device_aux_battery_info_message(
                 fields.push(device_aux_battery_info_message_battery_voltage_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     256.000000,
@@ -25497,6 +27571,7 @@ fn device_aux_battery_info_message(
                 fields.push(device_aux_battery_info_message_battery_status_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25509,6 +27584,7 @@ fn device_aux_battery_info_message(
                 fields.push(device_aux_battery_info_message_battery_identifier_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25521,6 +27597,7 @@ fn device_aux_battery_info_message(
                 fields.push(device_aux_battery_info_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25537,6 +27614,7 @@ fn device_aux_battery_info_message(
 fn device_aux_battery_info_message_device_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25557,11 +27635,13 @@ fn device_aux_battery_info_message_device_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_aux_battery_info_message_battery_voltage_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25582,11 +27662,13 @@ fn device_aux_battery_info_message_battery_voltage_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_aux_battery_info_message_battery_status_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25607,11 +27689,13 @@ fn device_aux_battery_info_message_battery_status_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_aux_battery_info_message_battery_identifier_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25632,11 +27716,13 @@ fn device_aux_battery_info_message_battery_identifier_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn device_aux_battery_info_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25657,6 +27743,7 @@ fn device_aux_battery_info_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Corresponds to file_id of workout or course.
@@ -25664,6 +27751,7 @@ fn training_file_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -25674,6 +27762,7 @@ fn training_file_message(
                 fields.push(training_file_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25686,6 +27775,7 @@ fn training_file_message(
                 fields.push(training_file_message_manufacturer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25705,6 +27795,7 @@ fn training_file_message(
                     fields.push(training_file_message_favero_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -25722,6 +27813,7 @@ fn training_file_message(
                     fields.push(training_file_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -25739,6 +27831,7 @@ fn training_file_message(
                     fields.push(training_file_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -25756,6 +27849,7 @@ fn training_file_message(
                     fields.push(training_file_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -25773,6 +27867,7 @@ fn training_file_message(
                     fields.push(training_file_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -25784,6 +27879,7 @@ fn training_file_message(
                     fields.push(training_file_message_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -25797,6 +27893,7 @@ fn training_file_message(
                 fields.push(training_file_message_serial_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25809,6 +27906,7 @@ fn training_file_message(
                 fields.push(training_file_message_time_created_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25821,6 +27919,7 @@ fn training_file_message(
                 fields.push(training_file_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -25837,6 +27936,7 @@ fn training_file_message(
 fn training_file_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25849,11 +27949,21 @@ fn training_file_message_type_field(
     } else {
         value
     };
-    data_field_with_info(0, "type", FieldDataType::File, scale, offset, units, value)
+    data_field_with_info(
+        0,
+        "type",
+        FieldDataType::File,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn training_file_message_manufacturer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25874,11 +27984,13 @@ fn training_file_message_manufacturer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn training_file_message_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25899,11 +28011,13 @@ fn training_file_message_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn training_file_message_favero_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25924,11 +28038,13 @@ fn training_file_message_favero_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn training_file_message_garmin_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25949,11 +28065,13 @@ fn training_file_message_garmin_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn training_file_message_serial_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25974,11 +28092,13 @@ fn training_file_message_serial_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn training_file_message_time_created_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -25999,11 +28119,13 @@ fn training_file_message_time_created_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn training_file_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26024,12 +28146,14 @@ fn training_file_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -26041,6 +28165,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_weather_report_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26053,6 +28178,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26066,6 +28192,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_condition_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26078,6 +28205,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_wind_direction_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26090,6 +28218,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_wind_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -26103,6 +28232,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_precipitation_probability_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26116,6 +28246,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_temperature_feels_like_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26128,6 +28259,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_relative_humidity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26141,6 +28273,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_location_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26153,6 +28286,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_observed_at_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26165,6 +28299,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_observed_location_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26177,6 +28312,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_observed_location_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26189,6 +28325,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_day_of_week_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26201,6 +28338,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_high_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26213,6 +28351,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_low_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26226,6 +28365,7 @@ fn weather_conditions_message(
                 fields.push(weather_conditions_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26242,6 +28382,7 @@ fn weather_conditions_message(
 fn weather_conditions_message_weather_report_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26262,11 +28403,13 @@ fn weather_conditions_message_weather_report_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26287,11 +28430,13 @@ fn weather_conditions_message_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_condition_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26312,11 +28457,13 @@ fn weather_conditions_message_condition_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_wind_direction_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26337,11 +28484,13 @@ fn weather_conditions_message_wind_direction_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_wind_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26362,11 +28511,13 @@ fn weather_conditions_message_wind_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_precipitation_probability_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26387,11 +28538,13 @@ fn weather_conditions_message_precipitation_probability_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_temperature_feels_like_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26412,11 +28565,13 @@ fn weather_conditions_message_temperature_feels_like_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_relative_humidity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26437,11 +28592,13 @@ fn weather_conditions_message_relative_humidity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_location_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26462,11 +28619,13 @@ fn weather_conditions_message_location_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_observed_at_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26487,11 +28646,13 @@ fn weather_conditions_message_observed_at_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_observed_location_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26512,11 +28673,13 @@ fn weather_conditions_message_observed_location_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_observed_location_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26537,11 +28700,13 @@ fn weather_conditions_message_observed_location_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_day_of_week_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26562,11 +28727,13 @@ fn weather_conditions_message_day_of_week_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_high_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26587,11 +28754,13 @@ fn weather_conditions_message_high_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_low_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26612,11 +28781,13 @@ fn weather_conditions_message_low_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_conditions_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26637,12 +28808,14 @@ fn weather_conditions_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_alert_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -26654,6 +28827,7 @@ fn weather_alert_message(
                 fields.push(weather_alert_message_report_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26667,6 +28841,7 @@ fn weather_alert_message(
                 fields.push(weather_alert_message_issue_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26680,6 +28855,7 @@ fn weather_alert_message(
                 fields.push(weather_alert_message_expire_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26693,6 +28869,7 @@ fn weather_alert_message(
                 fields.push(weather_alert_message_severity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26706,6 +28883,7 @@ fn weather_alert_message(
                 fields.push(weather_alert_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26718,6 +28896,7 @@ fn weather_alert_message(
                 fields.push(weather_alert_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26734,6 +28913,7 @@ fn weather_alert_message(
 fn weather_alert_message_report_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26754,11 +28934,13 @@ fn weather_alert_message_report_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_alert_message_issue_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26779,11 +28961,13 @@ fn weather_alert_message_issue_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_alert_message_expire_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26804,11 +28988,13 @@ fn weather_alert_message_expire_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_alert_message_severity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26829,11 +29015,13 @@ fn weather_alert_message_severity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_alert_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26854,11 +29042,13 @@ fn weather_alert_message_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weather_alert_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -26879,12 +29069,14 @@ fn weather_alert_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -26896,6 +29088,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26908,6 +29101,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26920,6 +29114,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26932,6 +29127,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_enhanced_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -26944,6 +29140,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_enhanced_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -26956,6 +29153,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_heading_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -26969,6 +29167,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_utc_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -26982,6 +29181,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_velocity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -26995,6 +29195,7 @@ fn gps_metadata_message(
                 fields.push(gps_metadata_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27011,6 +29212,7 @@ fn gps_metadata_message(
 fn gps_metadata_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27031,11 +29233,13 @@ fn gps_metadata_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27056,11 +29260,13 @@ fn gps_metadata_message_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27081,11 +29287,13 @@ fn gps_metadata_message_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_enhanced_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27106,11 +29314,13 @@ fn gps_metadata_message_enhanced_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_enhanced_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27131,11 +29341,13 @@ fn gps_metadata_message_enhanced_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_heading_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27156,11 +29368,13 @@ fn gps_metadata_message_heading_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_utc_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27181,11 +29395,13 @@ fn gps_metadata_message_utc_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_velocity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27206,11 +29422,13 @@ fn gps_metadata_message_velocity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gps_metadata_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27231,12 +29449,14 @@ fn gps_metadata_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn camera_event_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -27248,6 +29468,7 @@ fn camera_event_message(
                 fields.push(camera_event_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27260,6 +29481,7 @@ fn camera_event_message(
                 fields.push(camera_event_message_camera_event_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27272,6 +29494,7 @@ fn camera_event_message(
                 fields.push(camera_event_message_camera_file_uuid_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27284,6 +29507,7 @@ fn camera_event_message(
                 fields.push(camera_event_message_camera_orientation_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27297,6 +29521,7 @@ fn camera_event_message(
                 fields.push(camera_event_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27313,6 +29538,7 @@ fn camera_event_message(
 fn camera_event_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27333,11 +29559,13 @@ fn camera_event_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn camera_event_message_camera_event_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27358,11 +29586,13 @@ fn camera_event_message_camera_event_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn camera_event_message_camera_file_uuid_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27383,11 +29613,13 @@ fn camera_event_message_camera_file_uuid_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn camera_event_message_camera_orientation_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27408,11 +29640,13 @@ fn camera_event_message_camera_orientation_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn camera_event_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27433,12 +29667,14 @@ fn camera_event_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -27450,6 +29686,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27463,6 +29700,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_sample_time_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27476,6 +29714,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_gyro_x_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27489,6 +29728,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_gyro_y_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27502,6 +29742,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_gyro_z_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27515,6 +29756,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_calibrated_gyro_x_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27528,6 +29770,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_calibrated_gyro_y_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27541,6 +29784,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_calibrated_gyro_z_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27554,6 +29798,7 @@ fn gyroscope_data_message(
                 fields.push(gyroscope_data_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27570,6 +29815,7 @@ fn gyroscope_data_message(
 fn gyroscope_data_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27590,11 +29836,13 @@ fn gyroscope_data_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_sample_time_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27615,11 +29863,13 @@ fn gyroscope_data_message_sample_time_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_gyro_x_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27640,11 +29890,13 @@ fn gyroscope_data_message_gyro_x_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_gyro_y_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27665,11 +29917,13 @@ fn gyroscope_data_message_gyro_y_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_gyro_z_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27690,11 +29944,13 @@ fn gyroscope_data_message_gyro_z_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_calibrated_gyro_x_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27715,11 +29971,13 @@ fn gyroscope_data_message_calibrated_gyro_x_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_calibrated_gyro_y_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27740,11 +29998,13 @@ fn gyroscope_data_message_calibrated_gyro_y_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_calibrated_gyro_z_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27765,11 +30025,13 @@ fn gyroscope_data_message_calibrated_gyro_z_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn gyroscope_data_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27790,12 +30052,14 @@ fn gyroscope_data_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -27807,6 +30071,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27820,6 +30085,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_sample_time_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27833,6 +30099,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_accel_x_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27846,6 +30113,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_accel_y_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27859,6 +30127,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_accel_z_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27872,6 +30141,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_calibrated_accel_x_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27885,6 +30155,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_calibrated_accel_y_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27898,6 +30169,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_calibrated_accel_z_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27912,6 +30184,7 @@ fn accelerometer_data_message(
                     accelerometer_data_message_compressed_calibrated_accel_x_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -27927,6 +30200,7 @@ fn accelerometer_data_message(
                     accelerometer_data_message_compressed_calibrated_accel_y_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -27942,6 +30216,7 @@ fn accelerometer_data_message(
                     accelerometer_data_message_compressed_calibrated_accel_z_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -27956,6 +30231,7 @@ fn accelerometer_data_message(
                 fields.push(accelerometer_data_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -27972,6 +30248,7 @@ fn accelerometer_data_message(
 fn accelerometer_data_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -27992,11 +30269,13 @@ fn accelerometer_data_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_sample_time_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28017,11 +30296,13 @@ fn accelerometer_data_message_sample_time_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_accel_x_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28042,11 +30323,13 @@ fn accelerometer_data_message_accel_x_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_accel_y_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28067,11 +30350,13 @@ fn accelerometer_data_message_accel_y_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_accel_z_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28092,11 +30377,13 @@ fn accelerometer_data_message_accel_z_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_calibrated_accel_x_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28117,11 +30404,13 @@ fn accelerometer_data_message_calibrated_accel_x_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_calibrated_accel_y_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28142,11 +30431,13 @@ fn accelerometer_data_message_calibrated_accel_y_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_calibrated_accel_z_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28167,11 +30458,13 @@ fn accelerometer_data_message_calibrated_accel_z_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_compressed_calibrated_accel_x_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28192,11 +30485,13 @@ fn accelerometer_data_message_compressed_calibrated_accel_x_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_compressed_calibrated_accel_y_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28217,11 +30512,13 @@ fn accelerometer_data_message_compressed_calibrated_accel_y_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_compressed_calibrated_accel_z_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28242,11 +30539,13 @@ fn accelerometer_data_message_compressed_calibrated_accel_z_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn accelerometer_data_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28267,12 +30566,14 @@ fn accelerometer_data_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -28284,6 +30585,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28297,6 +30599,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_sample_time_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28310,6 +30613,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_mag_x_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28323,6 +30627,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_mag_y_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28336,6 +30641,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_mag_z_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28349,6 +30655,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_calibrated_mag_x_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28362,6 +30669,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_calibrated_mag_y_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28375,6 +30683,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_calibrated_mag_z_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28388,6 +30697,7 @@ fn magnetometer_data_message(
                 fields.push(magnetometer_data_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28404,6 +30714,7 @@ fn magnetometer_data_message(
 fn magnetometer_data_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28424,11 +30735,13 @@ fn magnetometer_data_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_sample_time_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28449,11 +30762,13 @@ fn magnetometer_data_message_sample_time_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_mag_x_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28474,11 +30789,13 @@ fn magnetometer_data_message_mag_x_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_mag_y_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28499,11 +30816,13 @@ fn magnetometer_data_message_mag_y_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_mag_z_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28524,11 +30843,13 @@ fn magnetometer_data_message_mag_z_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_calibrated_mag_x_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28549,11 +30870,13 @@ fn magnetometer_data_message_calibrated_mag_x_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_calibrated_mag_y_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28574,11 +30897,13 @@ fn magnetometer_data_message_calibrated_mag_y_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_calibrated_mag_z_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28599,11 +30924,13 @@ fn magnetometer_data_message_calibrated_mag_z_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn magnetometer_data_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28624,12 +30951,14 @@ fn magnetometer_data_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn barometer_data_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -28641,6 +30970,7 @@ fn barometer_data_message(
                 fields.push(barometer_data_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28654,6 +30984,7 @@ fn barometer_data_message(
                 fields.push(barometer_data_message_sample_time_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28667,6 +30998,7 @@ fn barometer_data_message(
                 fields.push(barometer_data_message_baro_pres_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28680,6 +31012,7 @@ fn barometer_data_message(
                 fields.push(barometer_data_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28696,6 +31029,7 @@ fn barometer_data_message(
 fn barometer_data_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28716,11 +31050,13 @@ fn barometer_data_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn barometer_data_message_sample_time_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28741,11 +31077,13 @@ fn barometer_data_message_sample_time_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn barometer_data_message_baro_pres_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28766,11 +31104,13 @@ fn barometer_data_message_baro_pres_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn barometer_data_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28791,12 +31131,14 @@ fn barometer_data_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -28808,6 +31150,7 @@ fn three_d_sensor_calibration_message(
                 fields.push(three_d_sensor_calibration_message_sensor_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28828,6 +31171,7 @@ fn three_d_sensor_calibration_message(
                     fields.push(three_d_sensor_calibration_message_accel_cal_factor_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -28845,6 +31189,7 @@ fn three_d_sensor_calibration_message(
                     fields.push(three_d_sensor_calibration_message_gyro_cal_factor_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -28856,6 +31201,7 @@ fn three_d_sensor_calibration_message(
                     fields.push(three_d_sensor_calibration_message_calibration_factor_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -28871,6 +31217,7 @@ fn three_d_sensor_calibration_message(
                     three_d_sensor_calibration_message_calibration_divisor_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -28885,6 +31232,7 @@ fn three_d_sensor_calibration_message(
                 fields.push(three_d_sensor_calibration_message_level_shift_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28898,6 +31246,7 @@ fn three_d_sensor_calibration_message(
                 fields.push(three_d_sensor_calibration_message_offset_cal_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28911,6 +31260,7 @@ fn three_d_sensor_calibration_message(
                 fields.push(three_d_sensor_calibration_message_orientation_matrix_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     65535.000000,
@@ -28924,6 +31274,7 @@ fn three_d_sensor_calibration_message(
                 fields.push(three_d_sensor_calibration_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -28940,6 +31291,7 @@ fn three_d_sensor_calibration_message(
 fn three_d_sensor_calibration_message_sensor_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28960,11 +31312,13 @@ fn three_d_sensor_calibration_message_sensor_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_calibration_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -28985,11 +31339,13 @@ fn three_d_sensor_calibration_message_calibration_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_accel_cal_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29010,11 +31366,13 @@ fn three_d_sensor_calibration_message_accel_cal_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_gyro_cal_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29035,11 +31393,13 @@ fn three_d_sensor_calibration_message_gyro_cal_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_calibration_divisor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29060,11 +31420,13 @@ fn three_d_sensor_calibration_message_calibration_divisor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_level_shift_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29085,11 +31447,13 @@ fn three_d_sensor_calibration_message_level_shift_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_offset_cal_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29110,11 +31474,13 @@ fn three_d_sensor_calibration_message_offset_cal_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_orientation_matrix_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29135,11 +31501,13 @@ fn three_d_sensor_calibration_message_orientation_matrix_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn three_d_sensor_calibration_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29160,12 +31528,14 @@ fn three_d_sensor_calibration_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn one_d_sensor_calibration_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -29177,6 +31547,7 @@ fn one_d_sensor_calibration_message(
                 fields.push(one_d_sensor_calibration_message_sensor_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29197,6 +31568,7 @@ fn one_d_sensor_calibration_message(
                     fields.push(one_d_sensor_calibration_message_baro_cal_factor_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -29208,6 +31580,7 @@ fn one_d_sensor_calibration_message(
                     fields.push(one_d_sensor_calibration_message_calibration_factor_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -29222,6 +31595,7 @@ fn one_d_sensor_calibration_message(
                 fields.push(one_d_sensor_calibration_message_calibration_divisor_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29235,6 +31609,7 @@ fn one_d_sensor_calibration_message(
                 fields.push(one_d_sensor_calibration_message_level_shift_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29248,6 +31623,7 @@ fn one_d_sensor_calibration_message(
                 fields.push(one_d_sensor_calibration_message_offset_cal_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29261,6 +31637,7 @@ fn one_d_sensor_calibration_message(
                 fields.push(one_d_sensor_calibration_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29277,6 +31654,7 @@ fn one_d_sensor_calibration_message(
 fn one_d_sensor_calibration_message_sensor_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29297,11 +31675,13 @@ fn one_d_sensor_calibration_message_sensor_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn one_d_sensor_calibration_message_calibration_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29322,11 +31702,13 @@ fn one_d_sensor_calibration_message_calibration_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn one_d_sensor_calibration_message_baro_cal_factor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29347,11 +31729,13 @@ fn one_d_sensor_calibration_message_baro_cal_factor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn one_d_sensor_calibration_message_calibration_divisor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29372,11 +31756,13 @@ fn one_d_sensor_calibration_message_calibration_divisor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn one_d_sensor_calibration_message_level_shift_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29397,11 +31783,13 @@ fn one_d_sensor_calibration_message_level_shift_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn one_d_sensor_calibration_message_offset_cal_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29422,11 +31810,13 @@ fn one_d_sensor_calibration_message_offset_cal_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn one_d_sensor_calibration_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29447,12 +31837,14 @@ fn one_d_sensor_calibration_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_frame_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -29464,6 +31856,7 @@ fn video_frame_message(
                 fields.push(video_frame_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29477,6 +31870,7 @@ fn video_frame_message(
                 fields.push(video_frame_message_frame_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29490,6 +31884,7 @@ fn video_frame_message(
                 fields.push(video_frame_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29506,6 +31901,7 @@ fn video_frame_message(
 fn video_frame_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29526,11 +31922,13 @@ fn video_frame_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_frame_message_frame_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29551,11 +31949,13 @@ fn video_frame_message_frame_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_frame_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29576,12 +31976,14 @@ fn video_frame_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -29593,6 +31995,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29606,6 +32009,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_time_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29619,6 +32023,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_pid_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29632,6 +32037,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_raw_data_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29645,6 +32051,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_pid_data_size_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29658,6 +32065,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_system_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29671,6 +32079,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_start_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29684,6 +32093,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_start_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29697,6 +32107,7 @@ fn obdii_data_message(
                 fields.push(obdii_data_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29713,6 +32124,7 @@ fn obdii_data_message(
 fn obdii_data_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29733,11 +32145,13 @@ fn obdii_data_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message_time_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29758,11 +32172,13 @@ fn obdii_data_message_time_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message_pid_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29775,11 +32191,21 @@ fn obdii_data_message_pid_field(
     } else {
         value
     };
-    data_field_with_info(2, "pid", FieldDataType::Byte, scale, offset, units, value)
+    data_field_with_info(
+        2,
+        "pid",
+        FieldDataType::Byte,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn obdii_data_message_raw_data_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29800,11 +32226,13 @@ fn obdii_data_message_raw_data_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message_pid_data_size_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29825,11 +32253,13 @@ fn obdii_data_message_pid_data_size_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message_system_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29850,11 +32280,13 @@ fn obdii_data_message_system_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message_start_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29875,11 +32307,13 @@ fn obdii_data_message_start_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message_start_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29900,11 +32334,13 @@ fn obdii_data_message_start_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn obdii_data_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -29925,12 +32361,14 @@ fn obdii_data_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn nmea_sentence_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -29942,6 +32380,7 @@ fn nmea_sentence_message(
                 fields.push(nmea_sentence_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29955,6 +32394,7 @@ fn nmea_sentence_message(
                 fields.push(nmea_sentence_message_sentence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29968,6 +32408,7 @@ fn nmea_sentence_message(
                 fields.push(nmea_sentence_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -29984,6 +32425,7 @@ fn nmea_sentence_message(
 fn nmea_sentence_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30004,11 +32446,13 @@ fn nmea_sentence_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn nmea_sentence_message_sentence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30029,11 +32473,13 @@ fn nmea_sentence_message_sentence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn nmea_sentence_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30054,12 +32500,14 @@ fn nmea_sentence_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -30071,6 +32519,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30084,6 +32533,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_system_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30097,6 +32547,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_pitch_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10430.380000,
@@ -30110,6 +32561,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_roll_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10430.380000,
@@ -30123,6 +32575,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_accel_lateral_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -30136,6 +32589,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_accel_normal_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -30149,6 +32603,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_turn_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1024.000000,
@@ -30161,6 +32616,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_stage_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30174,6 +32630,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_attitude_stage_complete_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30187,6 +32644,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_track_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10430.380000,
@@ -30199,6 +32657,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_validity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30212,6 +32671,7 @@ fn aviation_attitude_message(
                 fields.push(aviation_attitude_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30228,6 +32688,7 @@ fn aviation_attitude_message(
 fn aviation_attitude_message_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30248,11 +32709,13 @@ fn aviation_attitude_message_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_system_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30273,11 +32736,13 @@ fn aviation_attitude_message_system_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_pitch_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30298,11 +32763,13 @@ fn aviation_attitude_message_pitch_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_roll_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30323,11 +32790,13 @@ fn aviation_attitude_message_roll_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_accel_lateral_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30348,11 +32817,13 @@ fn aviation_attitude_message_accel_lateral_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_accel_normal_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30373,11 +32844,13 @@ fn aviation_attitude_message_accel_normal_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_turn_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30398,11 +32871,13 @@ fn aviation_attitude_message_turn_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_stage_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30423,11 +32898,13 @@ fn aviation_attitude_message_stage_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_attitude_stage_complete_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30448,11 +32925,13 @@ fn aviation_attitude_message_attitude_stage_complete_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_track_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30473,11 +32952,13 @@ fn aviation_attitude_message_track_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_validity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30498,11 +32979,13 @@ fn aviation_attitude_message_validity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn aviation_attitude_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30523,12 +33006,14 @@ fn aviation_attitude_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -30539,6 +33024,7 @@ fn video_message(
                 fields.push(video_message_url_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30551,6 +33037,7 @@ fn video_message(
                 fields.push(video_message_hosting_provider_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30564,6 +33051,7 @@ fn video_message(
                 fields.push(video_message_duration_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30580,6 +33068,7 @@ fn video_message(
 fn video_message_url_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30592,11 +33081,21 @@ fn video_message_url_field(
     } else {
         value
     };
-    data_field_with_info(0, "url", FieldDataType::String, scale, offset, units, value)
+    data_field_with_info(
+        0,
+        "url",
+        FieldDataType::String,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn video_message_hosting_provider_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30617,11 +33116,13 @@ fn video_message_hosting_provider_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_message_duration_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30642,12 +33143,14 @@ fn video_message_duration_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_title_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -30659,6 +33162,7 @@ fn video_title_message(
                 fields.push(video_title_message_message_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30671,6 +33175,7 @@ fn video_title_message(
                 fields.push(video_title_message_text_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30684,6 +33189,7 @@ fn video_title_message(
                 fields.push(video_title_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30700,6 +33206,7 @@ fn video_title_message(
 fn video_title_message_message_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30720,11 +33227,13 @@ fn video_title_message_message_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_title_message_text_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30745,11 +33254,13 @@ fn video_title_message_text_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_title_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30770,12 +33281,14 @@ fn video_title_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_description_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -30787,6 +33300,7 @@ fn video_description_message(
                 fields.push(video_description_message_message_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30799,6 +33313,7 @@ fn video_description_message(
                 fields.push(video_description_message_text_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30812,6 +33327,7 @@ fn video_description_message(
                 fields.push(video_description_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30828,6 +33344,7 @@ fn video_description_message(
 fn video_description_message_message_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30848,11 +33365,13 @@ fn video_description_message_message_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_description_message_text_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30873,11 +33392,13 @@ fn video_description_message_text_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_description_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -30898,12 +33419,14 @@ fn video_description_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_clip_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -30914,6 +33437,7 @@ fn video_clip_message(
                 fields.push(video_clip_message_clip_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30926,6 +33450,7 @@ fn video_clip_message(
                 fields.push(video_clip_message_start_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30938,6 +33463,7 @@ fn video_clip_message(
                 fields.push(video_clip_message_start_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30950,6 +33476,7 @@ fn video_clip_message(
                 fields.push(video_clip_message_end_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30962,6 +33489,7 @@ fn video_clip_message(
                 fields.push(video_clip_message_end_timestamp_ms_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30975,6 +33503,7 @@ fn video_clip_message(
                 fields.push(video_clip_message_clip_start_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -30988,6 +33517,7 @@ fn video_clip_message(
                 fields.push(video_clip_message_clip_end_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31004,6 +33534,7 @@ fn video_clip_message(
 fn video_clip_message_clip_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31024,11 +33555,13 @@ fn video_clip_message_clip_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_clip_message_start_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31049,11 +33582,13 @@ fn video_clip_message_start_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_clip_message_start_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31074,11 +33609,13 @@ fn video_clip_message_start_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_clip_message_end_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31099,11 +33636,13 @@ fn video_clip_message_end_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_clip_message_end_timestamp_ms_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31124,11 +33663,13 @@ fn video_clip_message_end_timestamp_ms_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_clip_message_clip_start_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31149,11 +33690,13 @@ fn video_clip_message_clip_start_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn video_clip_message_clip_end_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31174,12 +33717,14 @@ fn video_clip_message_clip_end_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -31190,6 +33735,7 @@ fn set_message(
                 fields.push(set_message_duration_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -31203,6 +33749,7 @@ fn set_message(
                 fields.push(set_message_repetitions_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31216,6 +33763,7 @@ fn set_message(
                 fields.push(set_message_weight_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     16.000000,
@@ -31228,6 +33776,7 @@ fn set_message(
                 fields.push(set_message_set_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31241,6 +33790,7 @@ fn set_message(
                 fields.push(set_message_start_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31253,6 +33803,7 @@ fn set_message(
                 fields.push(set_message_category_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31266,6 +33817,7 @@ fn set_message(
                 fields.push(set_message_category_subtype_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31278,6 +33830,7 @@ fn set_message(
                 fields.push(set_message_weight_display_unit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31290,6 +33843,7 @@ fn set_message(
                 fields.push(set_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31302,6 +33856,7 @@ fn set_message(
                 fields.push(set_message_wkt_step_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31315,6 +33870,7 @@ fn set_message(
                 fields.push(set_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31331,6 +33887,7 @@ fn set_message(
 fn set_message_duration_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31351,11 +33908,13 @@ fn set_message_duration_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_repetitions_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31376,11 +33935,13 @@ fn set_message_repetitions_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_weight_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31401,11 +33962,13 @@ fn set_message_weight_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_set_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31426,11 +33989,13 @@ fn set_message_set_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_start_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31451,11 +34016,13 @@ fn set_message_start_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_category_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31476,11 +34043,13 @@ fn set_message_category_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_category_subtype_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31501,11 +34070,13 @@ fn set_message_category_subtype_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_weight_display_unit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31526,11 +34097,13 @@ fn set_message_weight_display_unit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31551,11 +34124,13 @@ fn set_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_wkt_step_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31576,11 +34151,13 @@ fn set_message_wkt_step_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn set_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31601,12 +34178,14 @@ fn set_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -31617,6 +34196,7 @@ fn jump_message(
                 fields.push(jump_message_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31629,6 +34209,7 @@ fn jump_message(
                 fields.push(jump_message_height_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31641,6 +34222,7 @@ fn jump_message(
                 fields.push(jump_message_rotations_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31653,6 +34235,7 @@ fn jump_message(
                 fields.push(jump_message_hang_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31666,6 +34249,7 @@ fn jump_message(
                 fields.push(jump_message_score_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31678,6 +34262,7 @@ fn jump_message(
                 fields.push(jump_message_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31690,6 +34275,7 @@ fn jump_message(
                 fields.push(jump_message_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31705,6 +34291,7 @@ fn jump_message(
                 fields.push(jump_message_enhanced_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -31717,6 +34304,7 @@ fn jump_message(
                 fields.push(jump_message_enhanced_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -31729,6 +34317,7 @@ fn jump_message(
                 fields.push(jump_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31745,6 +34334,7 @@ fn jump_message(
 fn jump_message_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31765,11 +34355,13 @@ fn jump_message_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_height_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31790,11 +34382,13 @@ fn jump_message_height_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_rotations_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31815,11 +34409,13 @@ fn jump_message_rotations_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_hang_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31840,11 +34436,13 @@ fn jump_message_hang_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_score_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31865,11 +34463,13 @@ fn jump_message_score_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31890,11 +34490,13 @@ fn jump_message_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31915,11 +34517,13 @@ fn jump_message_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_enhanced_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31940,11 +34544,13 @@ fn jump_message_enhanced_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn jump_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -31965,12 +34571,14 @@ fn jump_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn climb_pro_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -31981,6 +34589,7 @@ fn climb_pro_message(
                 fields.push(climb_pro_message_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -31993,6 +34602,7 @@ fn climb_pro_message(
                 fields.push(climb_pro_message_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32005,6 +34615,7 @@ fn climb_pro_message(
                 fields.push(climb_pro_message_climb_pro_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32017,6 +34628,7 @@ fn climb_pro_message(
                 fields.push(climb_pro_message_climb_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32029,6 +34641,7 @@ fn climb_pro_message(
                 fields.push(climb_pro_message_climb_category_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32041,6 +34654,7 @@ fn climb_pro_message(
                 fields.push(climb_pro_message_current_dist_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32053,6 +34667,7 @@ fn climb_pro_message(
                 fields.push(climb_pro_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32069,6 +34684,7 @@ fn climb_pro_message(
 fn climb_pro_message_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32089,11 +34705,13 @@ fn climb_pro_message_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn climb_pro_message_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32114,11 +34732,13 @@ fn climb_pro_message_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn climb_pro_message_climb_pro_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32139,11 +34759,13 @@ fn climb_pro_message_climb_pro_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn climb_pro_message_climb_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32164,11 +34786,13 @@ fn climb_pro_message_climb_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn climb_pro_message_climb_category_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32189,11 +34813,13 @@ fn climb_pro_message_climb_category_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn climb_pro_message_current_dist_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32214,11 +34840,13 @@ fn climb_pro_message_current_dist_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn climb_pro_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32239,6 +34867,7 @@ fn climb_pro_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Must be logged before developer field is used
@@ -32246,6 +34875,7 @@ fn field_description_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -32256,6 +34886,7 @@ fn field_description_message(
                 fields.push(field_description_message_developer_data_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32268,6 +34899,7 @@ fn field_description_message(
                 fields.push(field_description_message_field_definition_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32280,6 +34912,7 @@ fn field_description_message(
                 fields.push(field_description_message_fit_base_type_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32292,6 +34925,7 @@ fn field_description_message(
                 fields.push(field_description_message_field_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32304,6 +34938,7 @@ fn field_description_message(
                 fields.push(field_description_message_array_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32316,6 +34951,7 @@ fn field_description_message(
                 fields.push(field_description_message_components_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32328,6 +34964,7 @@ fn field_description_message(
                 fields.push(field_description_message_scale_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32340,6 +34977,7 @@ fn field_description_message(
                 fields.push(field_description_message_offset_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32352,6 +34990,7 @@ fn field_description_message(
                 fields.push(field_description_message_units_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32364,6 +35003,7 @@ fn field_description_message(
                 fields.push(field_description_message_bits_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32376,6 +35016,7 @@ fn field_description_message(
                 fields.push(field_description_message_accumulate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32388,6 +35029,7 @@ fn field_description_message(
                 fields.push(field_description_message_fit_base_unit_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32400,6 +35042,7 @@ fn field_description_message(
                 fields.push(field_description_message_native_mesg_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32412,6 +35055,7 @@ fn field_description_message(
                 fields.push(field_description_message_native_field_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32428,6 +35072,7 @@ fn field_description_message(
 fn field_description_message_developer_data_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32448,11 +35093,13 @@ fn field_description_message_developer_data_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_field_definition_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32473,11 +35120,13 @@ fn field_description_message_field_definition_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_fit_base_type_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32498,11 +35147,13 @@ fn field_description_message_fit_base_type_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_field_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32523,11 +35174,13 @@ fn field_description_message_field_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_array_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32548,11 +35201,13 @@ fn field_description_message_array_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_components_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32573,11 +35228,13 @@ fn field_description_message_components_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_scale_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32598,11 +35255,13 @@ fn field_description_message_scale_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_offset_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32623,11 +35282,13 @@ fn field_description_message_offset_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_units_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32648,11 +35309,13 @@ fn field_description_message_units_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_bits_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32673,11 +35336,13 @@ fn field_description_message_bits_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_accumulate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32698,11 +35363,13 @@ fn field_description_message_accumulate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_fit_base_unit_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32723,11 +35390,13 @@ fn field_description_message_fit_base_unit_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_native_mesg_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32748,11 +35417,13 @@ fn field_description_message_native_mesg_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn field_description_message_native_field_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32773,6 +35444,7 @@ fn field_description_message_native_field_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Must be logged before field description
@@ -32780,6 +35452,7 @@ fn developer_data_id_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -32790,6 +35463,7 @@ fn developer_data_id_message(
                 fields.push(developer_data_id_message_developer_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32802,6 +35476,7 @@ fn developer_data_id_message(
                 fields.push(developer_data_id_message_application_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32814,6 +35489,7 @@ fn developer_data_id_message(
                 fields.push(developer_data_id_message_manufacturer_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32826,6 +35502,7 @@ fn developer_data_id_message(
                 fields.push(developer_data_id_message_developer_data_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32838,6 +35515,7 @@ fn developer_data_id_message(
                 fields.push(developer_data_id_message_application_version_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -32854,6 +35532,7 @@ fn developer_data_id_message(
 fn developer_data_id_message_developer_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32874,11 +35553,13 @@ fn developer_data_id_message_developer_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn developer_data_id_message_application_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32899,11 +35580,13 @@ fn developer_data_id_message_application_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn developer_data_id_message_manufacturer_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32924,11 +35607,13 @@ fn developer_data_id_message_manufacturer_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn developer_data_id_message_developer_data_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32949,11 +35634,13 @@ fn developer_data_id_message_developer_data_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn developer_data_id_message_application_version_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -32974,12 +35661,14 @@ fn developer_data_id_message_application_version_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -32990,6 +35679,7 @@ fn course_message(
                 fields.push(course_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33002,6 +35692,7 @@ fn course_message(
                 fields.push(course_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33014,6 +35705,7 @@ fn course_message(
                 fields.push(course_message_capabilities_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33026,6 +35718,7 @@ fn course_message(
                 fields.push(course_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33042,6 +35735,7 @@ fn course_message(
 fn course_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33062,11 +35756,13 @@ fn course_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33087,11 +35783,13 @@ fn course_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_message_capabilities_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33112,11 +35810,13 @@ fn course_message_capabilities_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33137,12 +35837,14 @@ fn course_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -33153,6 +35855,7 @@ fn course_point_message(
                 fields.push(course_point_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33165,6 +35868,7 @@ fn course_point_message(
                 fields.push(course_point_message_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33177,6 +35881,7 @@ fn course_point_message(
                 fields.push(course_point_message_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33189,6 +35894,7 @@ fn course_point_message(
                 fields.push(course_point_message_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -33201,6 +35907,7 @@ fn course_point_message(
                 fields.push(course_point_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33213,6 +35920,7 @@ fn course_point_message(
                 fields.push(course_point_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33225,6 +35933,7 @@ fn course_point_message(
                 fields.push(course_point_message_favorite_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33237,6 +35946,7 @@ fn course_point_message(
                 fields.push(course_point_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33253,6 +35963,7 @@ fn course_point_message(
 fn course_point_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33273,11 +35984,13 @@ fn course_point_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33298,11 +36011,13 @@ fn course_point_message_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33323,11 +36038,13 @@ fn course_point_message_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33348,11 +36065,13 @@ fn course_point_message_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33373,11 +36092,13 @@ fn course_point_message_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33398,11 +36119,13 @@ fn course_point_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message_favorite_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33423,11 +36146,13 @@ fn course_point_message_favorite_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn course_point_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33448,6 +36173,7 @@ fn course_point_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Unique Identification data for a segment file
@@ -33455,6 +36181,7 @@ fn segment_id_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -33466,6 +36193,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33479,6 +36207,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_uuid_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33492,6 +36221,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33505,6 +36235,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33518,6 +36249,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_user_profile_primary_key_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33531,6 +36263,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_device_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33544,6 +36277,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_default_race_leader_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33557,6 +36291,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_delete_status_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33570,6 +36305,7 @@ fn segment_id_message(
                 fields.push(segment_id_message_selection_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33586,6 +36322,7 @@ fn segment_id_message(
 fn segment_id_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33606,11 +36343,13 @@ fn segment_id_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_uuid_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33631,11 +36370,13 @@ fn segment_id_message_uuid_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33656,11 +36397,13 @@ fn segment_id_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33681,11 +36424,13 @@ fn segment_id_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_user_profile_primary_key_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33706,11 +36451,13 @@ fn segment_id_message_user_profile_primary_key_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_device_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33731,11 +36478,13 @@ fn segment_id_message_device_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_default_race_leader_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33756,11 +36505,13 @@ fn segment_id_message_default_race_leader_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_delete_status_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33781,11 +36532,13 @@ fn segment_id_message_delete_status_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_id_message_selection_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33806,6 +36559,7 @@ fn segment_id_message_selection_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Unique Identification data for an individual segment leader within a segment file
@@ -33813,6 +36567,7 @@ fn segment_leaderboard_entry_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -33824,6 +36579,7 @@ fn segment_leaderboard_entry_message(
                 fields.push(segment_leaderboard_entry_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33837,6 +36593,7 @@ fn segment_leaderboard_entry_message(
                 fields.push(segment_leaderboard_entry_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33850,6 +36607,7 @@ fn segment_leaderboard_entry_message(
                 fields.push(segment_leaderboard_entry_message_group_primary_key_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33863,6 +36621,7 @@ fn segment_leaderboard_entry_message(
                 fields.push(segment_leaderboard_entry_message_activity_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33876,6 +36635,7 @@ fn segment_leaderboard_entry_message(
                 fields.push(segment_leaderboard_entry_message_segment_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -33889,6 +36649,7 @@ fn segment_leaderboard_entry_message(
                 fields.push(segment_leaderboard_entry_message_activity_id_string_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33901,6 +36662,7 @@ fn segment_leaderboard_entry_message(
                 fields.push(segment_leaderboard_entry_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -33917,6 +36679,7 @@ fn segment_leaderboard_entry_message(
 fn segment_leaderboard_entry_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33937,11 +36700,13 @@ fn segment_leaderboard_entry_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_leaderboard_entry_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33962,11 +36727,13 @@ fn segment_leaderboard_entry_message_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_leaderboard_entry_message_group_primary_key_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -33987,11 +36754,13 @@ fn segment_leaderboard_entry_message_group_primary_key_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_leaderboard_entry_message_activity_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34012,11 +36781,13 @@ fn segment_leaderboard_entry_message_activity_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_leaderboard_entry_message_segment_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34037,11 +36808,13 @@ fn segment_leaderboard_entry_message_segment_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_leaderboard_entry_message_activity_id_string_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34062,11 +36835,13 @@ fn segment_leaderboard_entry_message_activity_id_string_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_leaderboard_entry_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34087,6 +36862,7 @@ fn segment_leaderboard_entry_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Navigation and race evaluation point for a segment decribing a point along the segment path and time it took each segment leader to reach that point
@@ -34094,6 +36870,7 @@ fn segment_point_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -34104,6 +36881,7 @@ fn segment_point_message(
                 fields.push(segment_point_message_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34116,6 +36894,7 @@ fn segment_point_message(
                 fields.push(segment_point_message_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34129,6 +36908,7 @@ fn segment_point_message(
                 fields.push(segment_point_message_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -34142,6 +36922,7 @@ fn segment_point_message(
                 fields.push(segment_point_message_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -34155,6 +36936,7 @@ fn segment_point_message(
                 fields.push(segment_point_message_leader_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34167,6 +36949,7 @@ fn segment_point_message(
                 fields.push(segment_point_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34183,6 +36966,7 @@ fn segment_point_message(
 fn segment_point_message_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34203,11 +36987,13 @@ fn segment_point_message_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_point_message_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34228,11 +37014,13 @@ fn segment_point_message_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_point_message_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34253,11 +37041,13 @@ fn segment_point_message_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_point_message_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34278,11 +37068,13 @@ fn segment_point_message_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_point_message_leader_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34303,11 +37095,13 @@ fn segment_point_message_leader_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_point_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -34328,12 +37122,14 @@ fn segment_point_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -34344,6 +37140,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34356,6 +37153,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_event_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34368,6 +37166,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_start_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34380,6 +37179,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_start_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34392,6 +37192,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_start_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34404,6 +37205,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_end_position_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34416,6 +37218,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_end_position_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34429,6 +37232,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_elapsed_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34442,6 +37246,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_timer_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34454,6 +37259,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -34473,6 +37279,7 @@ fn segment_lap_message(
                     fields.push(segment_lap_message_total_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -34484,6 +37291,7 @@ fn segment_lap_message(
                     fields.push(segment_lap_message_total_cycles_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -34497,6 +37305,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34510,6 +37319,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_fat_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34522,6 +37332,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34534,6 +37345,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34546,6 +37358,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34558,6 +37371,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34571,6 +37385,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34583,6 +37398,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34596,6 +37412,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34608,6 +37425,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34620,6 +37438,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_ascent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34632,6 +37451,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_descent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34644,6 +37464,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34656,6 +37477,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_event_group_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34669,6 +37491,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_nec_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34682,6 +37505,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_nec_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34695,6 +37519,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_swc_lat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34708,6 +37533,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_swc_long_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34720,6 +37546,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34732,6 +37559,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_normalized_power_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34744,6 +37572,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_left_right_balance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34756,6 +37585,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34768,6 +37598,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_work_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34780,6 +37611,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -34792,6 +37624,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -34804,6 +37637,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_gps_accuracy_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34816,6 +37650,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -34828,6 +37663,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_pos_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -34840,6 +37676,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_neg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -34852,6 +37689,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_pos_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -34864,6 +37702,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_neg_grade_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -34876,6 +37715,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34888,6 +37728,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -34900,6 +37741,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_moving_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34912,6 +37754,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_pos_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34924,6 +37767,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_neg_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34936,6 +37780,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_pos_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34948,6 +37793,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_neg_vertical_speed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34960,6 +37806,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_time_in_hr_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34972,6 +37819,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_time_in_speed_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34984,6 +37832,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_time_in_cadence_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -34996,6 +37845,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_time_in_power_zone_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -35008,6 +37858,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_repetition_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35020,6 +37871,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_min_altitude_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5.000000,
@@ -35032,6 +37884,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_min_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35044,6 +37897,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_active_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -35056,6 +37910,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_wkt_step_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35068,6 +37923,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_sport_event_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35080,6 +37936,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_left_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -35092,6 +37949,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_right_torque_effectiveness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -35104,6 +37962,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_left_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -35116,6 +37975,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_right_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -35128,6 +37988,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_combined_pedal_smoothness_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     2.000000,
@@ -35140,6 +38001,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_status_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35152,6 +38014,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_uuid_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35165,6 +38028,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_fractional_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -35178,6 +38042,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_fractional_cadence_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -35191,6 +38056,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_fractional_cycles_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     128.000000,
@@ -35203,6 +38069,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_front_gear_shift_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35215,6 +38082,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_rear_gear_shift_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35228,6 +38096,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_time_standing_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -35241,6 +38110,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_stand_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35254,6 +38124,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_left_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35267,6 +38138,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_right_pco_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35280,6 +38152,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_left_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -35293,6 +38166,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_left_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -35306,6 +38180,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_right_power_phase_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -35319,6 +38194,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_right_power_phase_peak_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     0.711111,
@@ -35332,6 +38208,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_power_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35345,6 +38222,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_power_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35358,6 +38236,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_cadence_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35371,6 +38250,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_max_cadence_position_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35384,6 +38264,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_manufacturer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35397,6 +38278,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_grit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35410,6 +38292,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_flow_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35423,6 +38306,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_grit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35436,6 +38320,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_avg_flow_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35449,6 +38334,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_fractional_ascent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -35462,6 +38348,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_total_fractional_descent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -35475,6 +38362,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35487,6 +38375,7 @@ fn segment_lap_message(
                 fields.push(segment_lap_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -35503,6 +38392,7 @@ fn segment_lap_message(
 fn segment_lap_message_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35523,11 +38413,13 @@ fn segment_lap_message_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_event_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35548,11 +38440,13 @@ fn segment_lap_message_event_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_start_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35573,11 +38467,13 @@ fn segment_lap_message_start_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_start_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35598,11 +38494,13 @@ fn segment_lap_message_start_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_start_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35623,11 +38521,13 @@ fn segment_lap_message_start_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_end_position_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35648,11 +38548,13 @@ fn segment_lap_message_end_position_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_end_position_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35673,11 +38575,13 @@ fn segment_lap_message_end_position_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_elapsed_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35698,11 +38602,13 @@ fn segment_lap_message_total_elapsed_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_timer_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35723,11 +38629,13 @@ fn segment_lap_message_total_timer_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35748,11 +38656,13 @@ fn segment_lap_message_total_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35773,11 +38683,13 @@ fn segment_lap_message_total_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_strokes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35798,11 +38710,13 @@ fn segment_lap_message_total_strokes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35823,11 +38737,13 @@ fn segment_lap_message_total_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_fat_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35848,11 +38764,13 @@ fn segment_lap_message_total_fat_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35873,11 +38791,13 @@ fn segment_lap_message_avg_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35898,11 +38818,13 @@ fn segment_lap_message_max_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35923,11 +38845,13 @@ fn segment_lap_message_avg_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35948,11 +38872,13 @@ fn segment_lap_message_max_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35973,11 +38899,13 @@ fn segment_lap_message_avg_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -35998,11 +38926,13 @@ fn segment_lap_message_max_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36023,11 +38953,13 @@ fn segment_lap_message_avg_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36048,11 +38980,13 @@ fn segment_lap_message_max_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_ascent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36073,11 +39007,13 @@ fn segment_lap_message_total_ascent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_descent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36098,11 +39034,13 @@ fn segment_lap_message_total_descent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36123,11 +39061,13 @@ fn segment_lap_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_event_group_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36148,11 +39088,13 @@ fn segment_lap_message_event_group_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_nec_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36173,11 +39115,13 @@ fn segment_lap_message_nec_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_nec_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36198,11 +39142,13 @@ fn segment_lap_message_nec_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_swc_lat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36223,11 +39169,13 @@ fn segment_lap_message_swc_lat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_swc_long_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36248,11 +39196,13 @@ fn segment_lap_message_swc_long_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36273,11 +39223,13 @@ fn segment_lap_message_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_normalized_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36298,11 +39250,13 @@ fn segment_lap_message_normalized_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_left_right_balance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36323,11 +39277,13 @@ fn segment_lap_message_left_right_balance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36348,11 +39304,13 @@ fn segment_lap_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_work_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36373,11 +39331,13 @@ fn segment_lap_message_total_work_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36398,11 +39358,13 @@ fn segment_lap_message_avg_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36423,11 +39385,13 @@ fn segment_lap_message_max_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_gps_accuracy_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36448,11 +39412,13 @@ fn segment_lap_message_gps_accuracy_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36473,11 +39439,13 @@ fn segment_lap_message_avg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_pos_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36498,11 +39466,13 @@ fn segment_lap_message_avg_pos_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_neg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36523,11 +39493,13 @@ fn segment_lap_message_avg_neg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_pos_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36548,11 +39520,13 @@ fn segment_lap_message_max_pos_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_neg_grade_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36573,11 +39547,13 @@ fn segment_lap_message_max_neg_grade_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36598,11 +39574,13 @@ fn segment_lap_message_avg_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36623,11 +39601,13 @@ fn segment_lap_message_max_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_moving_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36648,11 +39628,13 @@ fn segment_lap_message_total_moving_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_pos_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36673,11 +39655,13 @@ fn segment_lap_message_avg_pos_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_neg_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36698,11 +39682,13 @@ fn segment_lap_message_avg_neg_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_pos_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36723,11 +39709,13 @@ fn segment_lap_message_max_pos_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_neg_vertical_speed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36748,11 +39736,13 @@ fn segment_lap_message_max_neg_vertical_speed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_time_in_hr_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36773,11 +39763,13 @@ fn segment_lap_message_time_in_hr_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_time_in_speed_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36798,11 +39790,13 @@ fn segment_lap_message_time_in_speed_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_time_in_cadence_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36823,11 +39817,13 @@ fn segment_lap_message_time_in_cadence_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_time_in_power_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36848,11 +39844,13 @@ fn segment_lap_message_time_in_power_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_repetition_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36873,11 +39871,13 @@ fn segment_lap_message_repetition_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_min_altitude_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36898,11 +39898,13 @@ fn segment_lap_message_min_altitude_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_min_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36923,11 +39925,13 @@ fn segment_lap_message_min_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_active_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36948,11 +39952,13 @@ fn segment_lap_message_active_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_wkt_step_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36973,11 +39979,13 @@ fn segment_lap_message_wkt_step_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_sport_event_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -36998,11 +40006,13 @@ fn segment_lap_message_sport_event_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_left_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37023,11 +40033,13 @@ fn segment_lap_message_avg_left_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_right_torque_effectiveness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37048,11 +40060,13 @@ fn segment_lap_message_avg_right_torque_effectiveness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_left_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37073,11 +40087,13 @@ fn segment_lap_message_avg_left_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_right_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37098,11 +40114,13 @@ fn segment_lap_message_avg_right_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_combined_pedal_smoothness_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37123,11 +40141,13 @@ fn segment_lap_message_avg_combined_pedal_smoothness_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_status_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37148,11 +40168,13 @@ fn segment_lap_message_status_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_uuid_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37173,11 +40195,13 @@ fn segment_lap_message_uuid_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_fractional_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37198,11 +40222,13 @@ fn segment_lap_message_avg_fractional_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_fractional_cadence_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37223,11 +40249,13 @@ fn segment_lap_message_max_fractional_cadence_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_fractional_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37248,11 +40276,13 @@ fn segment_lap_message_total_fractional_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_front_gear_shift_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37273,11 +40303,13 @@ fn segment_lap_message_front_gear_shift_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_rear_gear_shift_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37298,11 +40330,13 @@ fn segment_lap_message_rear_gear_shift_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_time_standing_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37323,11 +40357,13 @@ fn segment_lap_message_time_standing_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_stand_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37348,11 +40384,13 @@ fn segment_lap_message_stand_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_left_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37373,11 +40411,13 @@ fn segment_lap_message_avg_left_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_right_pco_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37398,11 +40438,13 @@ fn segment_lap_message_avg_right_pco_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_left_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37423,11 +40465,13 @@ fn segment_lap_message_avg_left_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_left_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37448,11 +40492,13 @@ fn segment_lap_message_avg_left_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_right_power_phase_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37473,11 +40519,13 @@ fn segment_lap_message_avg_right_power_phase_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_right_power_phase_peak_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37498,11 +40546,13 @@ fn segment_lap_message_avg_right_power_phase_peak_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_power_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37523,11 +40573,13 @@ fn segment_lap_message_avg_power_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_power_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37548,11 +40600,13 @@ fn segment_lap_message_max_power_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_cadence_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37573,11 +40627,13 @@ fn segment_lap_message_avg_cadence_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_max_cadence_position_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37598,11 +40654,13 @@ fn segment_lap_message_max_cadence_position_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_manufacturer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37623,11 +40681,13 @@ fn segment_lap_message_manufacturer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_grit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37648,11 +40708,13 @@ fn segment_lap_message_total_grit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_flow_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37673,11 +40735,13 @@ fn segment_lap_message_total_flow_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_grit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37698,11 +40762,13 @@ fn segment_lap_message_avg_grit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_avg_flow_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37723,11 +40789,13 @@ fn segment_lap_message_avg_flow_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_fractional_ascent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37748,11 +40816,13 @@ fn segment_lap_message_total_fractional_ascent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_total_fractional_descent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37773,11 +40843,13 @@ fn segment_lap_message_total_fractional_descent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37798,11 +40870,13 @@ fn segment_lap_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_lap_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37823,6 +40897,7 @@ fn segment_lap_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Summary of the unique segment and leaderboard information associated with a segment file. This message is used to compile a segment list file describing all segment files on a device. The segment list file is used when refreshing the contents of a segment file with the latest available leaderboard information.
@@ -37830,6 +40905,7 @@ fn segment_file_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -37841,6 +40917,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_file_uuid_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37854,6 +40931,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37867,6 +40945,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_user_profile_primary_key_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37880,6 +40959,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_leader_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37893,6 +40973,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_leader_group_primary_key_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37906,6 +40987,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_leader_activity_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37919,6 +41001,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_leader_activity_id_string_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37932,6 +41015,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_default_race_leader_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37944,6 +41028,7 @@ fn segment_file_message(
                 fields.push(segment_file_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -37960,6 +41045,7 @@ fn segment_file_message(
 fn segment_file_message_file_uuid_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -37980,11 +41066,13 @@ fn segment_file_message_file_uuid_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38005,11 +41093,13 @@ fn segment_file_message_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_user_profile_primary_key_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38030,11 +41120,13 @@ fn segment_file_message_user_profile_primary_key_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_leader_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38055,11 +41147,13 @@ fn segment_file_message_leader_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_leader_group_primary_key_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38080,11 +41174,13 @@ fn segment_file_message_leader_group_primary_key_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_leader_activity_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38105,11 +41201,13 @@ fn segment_file_message_leader_activity_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_leader_activity_id_string_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38130,11 +41228,13 @@ fn segment_file_message_leader_activity_id_string_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_default_race_leader_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38155,11 +41255,13 @@ fn segment_file_message_default_race_leader_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn segment_file_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38180,12 +41282,14 @@ fn segment_file_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -38196,6 +41300,7 @@ fn workout_message(
                 fields.push(workout_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38208,6 +41313,7 @@ fn workout_message(
                 fields.push(workout_message_capabilities_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38221,6 +41327,7 @@ fn workout_message(
                 fields.push(workout_message_num_valid_steps_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38233,6 +41340,7 @@ fn workout_message(
                 fields.push(workout_message_wkt_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38245,6 +41353,7 @@ fn workout_message(
                 fields.push(workout_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38257,6 +41366,7 @@ fn workout_message(
                 fields.push(workout_message_pool_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -38269,6 +41379,7 @@ fn workout_message(
                 fields.push(workout_message_pool_length_unit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38285,6 +41396,7 @@ fn workout_message(
 fn workout_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38305,11 +41417,13 @@ fn workout_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_message_capabilities_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38330,11 +41444,13 @@ fn workout_message_capabilities_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_message_num_valid_steps_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38355,11 +41471,13 @@ fn workout_message_num_valid_steps_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_message_wkt_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38380,11 +41498,13 @@ fn workout_message_wkt_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38405,11 +41525,13 @@ fn workout_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_message_pool_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38430,11 +41552,13 @@ fn workout_message_pool_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_message_pool_length_unit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38455,12 +41579,14 @@ fn workout_message_pool_length_unit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_session_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -38471,6 +41597,7 @@ fn workout_session_message(
                 fields.push(workout_session_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38483,6 +41610,7 @@ fn workout_session_message(
                 fields.push(workout_session_message_sub_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38495,6 +41623,7 @@ fn workout_session_message(
                 fields.push(workout_session_message_num_valid_steps_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38507,6 +41636,7 @@ fn workout_session_message(
                 fields.push(workout_session_message_first_step_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38519,6 +41649,7 @@ fn workout_session_message(
                 fields.push(workout_session_message_pool_length_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -38531,6 +41662,7 @@ fn workout_session_message(
                 fields.push(workout_session_message_pool_length_unit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38543,6 +41675,7 @@ fn workout_session_message(
                 fields.push(workout_session_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38559,6 +41692,7 @@ fn workout_session_message(
 fn workout_session_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38579,11 +41713,13 @@ fn workout_session_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_session_message_sub_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38604,11 +41740,13 @@ fn workout_session_message_sub_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_session_message_num_valid_steps_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38629,11 +41767,13 @@ fn workout_session_message_num_valid_steps_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_session_message_first_step_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38654,11 +41794,13 @@ fn workout_session_message_first_step_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_session_message_pool_length_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38679,11 +41821,13 @@ fn workout_session_message_pool_length_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_session_message_pool_length_unit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38704,11 +41848,13 @@ fn workout_session_message_pool_length_unit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_session_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -38729,12 +41875,14 @@ fn workout_session_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -38745,6 +41893,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_wkt_step_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38757,6 +41906,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_duration_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -38776,6 +41926,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_time_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -38793,6 +41944,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_time_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -38810,6 +41962,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_distance_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         100.000000,
@@ -38827,6 +41980,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_hr_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38844,6 +41998,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_hr_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38861,6 +42016,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_calories_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38878,6 +42034,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38895,6 +42052,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38912,6 +42070,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38929,6 +42088,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38946,6 +42106,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38963,6 +42124,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38980,6 +42142,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -38997,6 +42160,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_step_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39014,6 +42178,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_power_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39031,6 +42196,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_power_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39048,6 +42214,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_reps_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39059,6 +42226,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_duration_value_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39072,6 +42240,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_target_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39091,6 +42260,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_target_speed_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39108,6 +42278,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_target_hr_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39125,6 +42296,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_target_cadence_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39142,6 +42314,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_target_power_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39159,6 +42332,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_steps_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39176,6 +42350,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_time_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -39193,6 +42368,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_distance_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         100.000000,
@@ -39210,6 +42386,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_calories_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39227,6 +42404,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_hr_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39244,6 +42422,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_hr_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39261,6 +42440,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_power_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39278,6 +42458,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_repeat_power_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39295,6 +42476,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_target_stroke_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39306,6 +42488,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_target_value_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39326,6 +42509,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_speed_low_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -39343,6 +42527,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_heart_rate_low_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39360,6 +42545,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_cadence_low_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39377,6 +42563,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_power_low_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39388,6 +42575,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_value_low_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39408,6 +42596,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_speed_high_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1000.000000,
@@ -39425,6 +42614,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_heart_rate_high_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39442,6 +42632,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_cadence_high_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39459,6 +42650,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_power_high_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39470,6 +42662,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_custom_target_value_high_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39483,6 +42676,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_intensity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39495,6 +42689,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_notes_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39507,6 +42702,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_equipment_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39519,6 +42715,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_exercise_category_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39531,6 +42728,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_exercise_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39543,6 +42741,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_exercise_weight_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -39555,6 +42754,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_weight_display_unit_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39567,6 +42767,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_secondary_target_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39586,6 +42787,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_secondary_target_speed_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39603,6 +42805,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_secondary_target_hr_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39620,6 +42823,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_secondary_target_cadence_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39637,6 +42841,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_secondary_target_power_zone_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39654,6 +42859,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_secondary_target_stroke_type_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39665,6 +42871,7 @@ fn workout_step_message(
                     fields.push(workout_step_message_secondary_target_value_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -39686,6 +42893,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_speed_low_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1000.000000,
@@ -39705,6 +42913,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_heart_rate_low_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39724,6 +42933,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_cadence_low_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39743,6 +42953,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_power_low_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39756,6 +42967,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_value_low_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39778,6 +42990,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_speed_high_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1000.000000,
@@ -39797,6 +43010,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_heart_rate_high_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39816,6 +43030,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_cadence_high_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39835,6 +43050,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_power_high_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39848,6 +43064,7 @@ fn workout_step_message(
                         workout_step_message_secondary_custom_target_value_high_field(
                             mesg_num,
                             accumlators,
+                            options,
                             data_map,
                             false,
                             1.000000,
@@ -39862,6 +43079,7 @@ fn workout_step_message(
                 fields.push(workout_step_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -39878,6 +43096,7 @@ fn workout_step_message(
 fn workout_step_message_wkt_step_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -39898,11 +43117,13 @@ fn workout_step_message_wkt_step_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -39923,11 +43144,13 @@ fn workout_step_message_duration_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -39948,11 +43171,13 @@ fn workout_step_message_duration_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -39973,11 +43198,13 @@ fn workout_step_message_duration_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -39998,11 +43225,13 @@ fn workout_step_message_duration_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_hr_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40023,11 +43252,13 @@ fn workout_step_message_duration_hr_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40048,11 +43279,13 @@ fn workout_step_message_duration_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_step_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40073,11 +43306,13 @@ fn workout_step_message_duration_step_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40098,11 +43333,13 @@ fn workout_step_message_duration_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_duration_reps_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40123,11 +43360,13 @@ fn workout_step_message_duration_reps_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_target_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40148,11 +43387,13 @@ fn workout_step_message_target_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_target_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40173,11 +43414,13 @@ fn workout_step_message_target_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_target_speed_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40198,11 +43441,13 @@ fn workout_step_message_target_speed_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_target_hr_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40223,11 +43468,13 @@ fn workout_step_message_target_hr_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_target_cadence_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40248,11 +43495,13 @@ fn workout_step_message_target_cadence_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_target_power_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40273,11 +43522,13 @@ fn workout_step_message_target_power_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_repeat_steps_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40298,11 +43549,13 @@ fn workout_step_message_repeat_steps_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_repeat_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40323,11 +43576,13 @@ fn workout_step_message_repeat_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_repeat_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40348,11 +43603,13 @@ fn workout_step_message_repeat_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_repeat_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40373,11 +43630,13 @@ fn workout_step_message_repeat_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_repeat_hr_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40398,11 +43657,13 @@ fn workout_step_message_repeat_hr_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_repeat_power_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40423,11 +43684,13 @@ fn workout_step_message_repeat_power_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_target_stroke_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40448,11 +43711,13 @@ fn workout_step_message_target_stroke_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_value_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40473,11 +43738,13 @@ fn workout_step_message_custom_target_value_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_speed_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40498,11 +43765,13 @@ fn workout_step_message_custom_target_speed_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_heart_rate_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40523,11 +43792,13 @@ fn workout_step_message_custom_target_heart_rate_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_cadence_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40548,11 +43819,13 @@ fn workout_step_message_custom_target_cadence_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_power_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40573,11 +43846,13 @@ fn workout_step_message_custom_target_power_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_value_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40598,11 +43873,13 @@ fn workout_step_message_custom_target_value_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_speed_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40623,11 +43900,13 @@ fn workout_step_message_custom_target_speed_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_heart_rate_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40648,11 +43927,13 @@ fn workout_step_message_custom_target_heart_rate_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_cadence_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40673,11 +43954,13 @@ fn workout_step_message_custom_target_cadence_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_custom_target_power_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40698,11 +43981,13 @@ fn workout_step_message_custom_target_power_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_intensity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40723,11 +44008,13 @@ fn workout_step_message_intensity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_notes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40748,11 +44035,13 @@ fn workout_step_message_notes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_equipment_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40773,11 +44062,13 @@ fn workout_step_message_equipment_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_exercise_category_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40798,11 +44089,13 @@ fn workout_step_message_exercise_category_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_exercise_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40823,11 +44116,13 @@ fn workout_step_message_exercise_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_exercise_weight_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40848,11 +44143,13 @@ fn workout_step_message_exercise_weight_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_weight_display_unit_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40873,11 +44170,13 @@ fn workout_step_message_weight_display_unit_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_target_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40898,11 +44197,13 @@ fn workout_step_message_secondary_target_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_target_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40923,11 +44224,13 @@ fn workout_step_message_secondary_target_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_target_speed_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40948,11 +44251,13 @@ fn workout_step_message_secondary_target_speed_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_target_hr_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40973,11 +44278,13 @@ fn workout_step_message_secondary_target_hr_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_target_cadence_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -40998,11 +44305,13 @@ fn workout_step_message_secondary_target_cadence_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_target_power_zone_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41023,11 +44332,13 @@ fn workout_step_message_secondary_target_power_zone_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_target_stroke_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41048,11 +44359,13 @@ fn workout_step_message_secondary_target_stroke_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_value_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41073,11 +44386,13 @@ fn workout_step_message_secondary_custom_target_value_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_speed_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41098,11 +44413,13 @@ fn workout_step_message_secondary_custom_target_speed_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_heart_rate_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41123,11 +44440,13 @@ fn workout_step_message_secondary_custom_target_heart_rate_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_cadence_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41148,11 +44467,13 @@ fn workout_step_message_secondary_custom_target_cadence_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_power_low_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41173,11 +44494,13 @@ fn workout_step_message_secondary_custom_target_power_low_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_value_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41198,11 +44521,13 @@ fn workout_step_message_secondary_custom_target_value_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_speed_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41223,11 +44548,13 @@ fn workout_step_message_secondary_custom_target_speed_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_heart_rate_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41248,11 +44575,13 @@ fn workout_step_message_secondary_custom_target_heart_rate_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_cadence_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41273,11 +44602,13 @@ fn workout_step_message_secondary_custom_target_cadence_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_secondary_custom_target_power_high_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41298,11 +44629,13 @@ fn workout_step_message_secondary_custom_target_power_high_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn workout_step_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41323,12 +44656,14 @@ fn workout_step_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exercise_title_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -41339,6 +44674,7 @@ fn exercise_title_message(
                 fields.push(exercise_title_message_exercise_category_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41351,6 +44687,7 @@ fn exercise_title_message(
                 fields.push(exercise_title_message_exercise_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41363,6 +44700,7 @@ fn exercise_title_message(
                 fields.push(exercise_title_message_wkt_step_name_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41375,6 +44713,7 @@ fn exercise_title_message(
                 fields.push(exercise_title_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41391,6 +44730,7 @@ fn exercise_title_message(
 fn exercise_title_message_exercise_category_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41411,11 +44751,13 @@ fn exercise_title_message_exercise_category_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exercise_title_message_exercise_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41436,11 +44778,13 @@ fn exercise_title_message_exercise_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exercise_title_message_wkt_step_name_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41461,11 +44805,13 @@ fn exercise_title_message_wkt_step_name_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exercise_title_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41486,12 +44832,14 @@ fn exercise_title_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -41503,6 +44851,7 @@ fn schedule_message(
                 fields.push(schedule_message_manufacturer_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41523,6 +44872,7 @@ fn schedule_message(
                     fields.push(schedule_message_favero_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -41540,6 +44890,7 @@ fn schedule_message(
                     fields.push(schedule_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -41557,6 +44908,7 @@ fn schedule_message(
                     fields.push(schedule_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -41574,6 +44926,7 @@ fn schedule_message(
                     fields.push(schedule_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -41591,6 +44944,7 @@ fn schedule_message(
                     fields.push(schedule_message_garmin_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -41602,6 +44956,7 @@ fn schedule_message(
                     fields.push(schedule_message_product_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -41616,6 +44971,7 @@ fn schedule_message(
                 fields.push(schedule_message_serial_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41629,6 +44985,7 @@ fn schedule_message(
                 fields.push(schedule_message_time_created_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41642,6 +44999,7 @@ fn schedule_message(
                 fields.push(schedule_message_completed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41654,6 +45012,7 @@ fn schedule_message(
                 fields.push(schedule_message_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41666,6 +45025,7 @@ fn schedule_message(
                 fields.push(schedule_message_scheduled_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41682,6 +45042,7 @@ fn schedule_message(
 fn schedule_message_manufacturer_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41702,11 +45063,13 @@ fn schedule_message_manufacturer_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41727,11 +45090,13 @@ fn schedule_message_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_favero_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41752,11 +45117,13 @@ fn schedule_message_favero_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_garmin_product_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41777,11 +45144,13 @@ fn schedule_message_garmin_product_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_serial_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41802,11 +45171,13 @@ fn schedule_message_serial_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_time_created_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41827,11 +45198,13 @@ fn schedule_message_time_created_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_completed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41852,11 +45225,13 @@ fn schedule_message_completed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41877,11 +45252,13 @@ fn schedule_message_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn schedule_message_scheduled_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -41902,12 +45279,14 @@ fn schedule_message_scheduled_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -41919,6 +45298,7 @@ fn totals_message(
                 fields.push(totals_message_timer_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41931,6 +45311,7 @@ fn totals_message(
                 fields.push(totals_message_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41943,6 +45324,7 @@ fn totals_message(
                 fields.push(totals_message_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41955,6 +45337,7 @@ fn totals_message(
                 fields.push(totals_message_sport_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41968,6 +45351,7 @@ fn totals_message(
                 fields.push(totals_message_elapsed_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41980,6 +45364,7 @@ fn totals_message(
                 fields.push(totals_message_sessions_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -41992,6 +45377,7 @@ fn totals_message(
                 fields.push(totals_message_active_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42004,6 +45390,7 @@ fn totals_message(
                 fields.push(totals_message_sport_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42016,6 +45403,7 @@ fn totals_message(
                 fields.push(totals_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42028,6 +45416,7 @@ fn totals_message(
                 fields.push(totals_message_message_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42044,6 +45433,7 @@ fn totals_message(
 fn totals_message_timer_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42064,11 +45454,13 @@ fn totals_message_timer_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42089,11 +45481,13 @@ fn totals_message_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42114,11 +45508,13 @@ fn totals_message_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_sport_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42139,11 +45535,13 @@ fn totals_message_sport_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_elapsed_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42164,11 +45562,13 @@ fn totals_message_elapsed_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_sessions_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42189,11 +45589,13 @@ fn totals_message_sessions_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_active_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42214,11 +45616,13 @@ fn totals_message_active_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_sport_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42239,11 +45643,13 @@ fn totals_message_sport_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42264,11 +45670,13 @@ fn totals_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn totals_message_message_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42289,12 +45697,14 @@ fn totals_message_message_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -42305,6 +45715,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_weight_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -42317,6 +45728,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_percent_fat_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -42329,6 +45741,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_percent_hydration_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -42341,6 +45754,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_visceral_fat_mass_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -42353,6 +45767,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_bone_mass_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -42365,6 +45780,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_muscle_mass_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -42377,6 +45793,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_basal_met_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     4.000000,
@@ -42389,6 +45806,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_physique_rating_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42402,6 +45820,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_active_met_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     4.000000,
@@ -42414,6 +45833,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_metabolic_age_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42426,6 +45846,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_visceral_fat_rating_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42439,6 +45860,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_user_profile_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42451,6 +45873,7 @@ fn weight_scale_message(
                 fields.push(weight_scale_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42467,6 +45890,7 @@ fn weight_scale_message(
 fn weight_scale_message_weight_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42487,11 +45911,13 @@ fn weight_scale_message_weight_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_percent_fat_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42512,11 +45938,13 @@ fn weight_scale_message_percent_fat_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_percent_hydration_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42537,11 +45965,13 @@ fn weight_scale_message_percent_hydration_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_visceral_fat_mass_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42562,11 +45992,13 @@ fn weight_scale_message_visceral_fat_mass_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_bone_mass_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42587,11 +46019,13 @@ fn weight_scale_message_bone_mass_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_muscle_mass_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42612,11 +46046,13 @@ fn weight_scale_message_muscle_mass_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_basal_met_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42637,11 +46073,13 @@ fn weight_scale_message_basal_met_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_physique_rating_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42662,11 +46100,13 @@ fn weight_scale_message_physique_rating_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_active_met_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42687,11 +46127,13 @@ fn weight_scale_message_active_met_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_metabolic_age_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42712,11 +46154,13 @@ fn weight_scale_message_metabolic_age_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_visceral_fat_rating_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42737,11 +46181,13 @@ fn weight_scale_message_visceral_fat_rating_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_user_profile_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42762,11 +46208,13 @@ fn weight_scale_message_user_profile_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn weight_scale_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42787,12 +46235,14 @@ fn weight_scale_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -42803,6 +46253,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_systolic_pressure_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42815,6 +46266,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_diastolic_pressure_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42827,6 +46279,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_mean_arterial_pressure_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42839,6 +46292,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_map_3_sample_mean_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42851,6 +46305,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_map_morning_values_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42863,6 +46318,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_map_evening_values_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42875,6 +46331,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42887,6 +46344,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_heart_rate_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42899,6 +46357,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_status_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42912,6 +46371,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_user_profile_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42924,6 +46384,7 @@ fn blood_pressure_message(
                 fields.push(blood_pressure_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -42940,6 +46401,7 @@ fn blood_pressure_message(
 fn blood_pressure_message_systolic_pressure_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42960,11 +46422,13 @@ fn blood_pressure_message_systolic_pressure_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_diastolic_pressure_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -42985,11 +46449,13 @@ fn blood_pressure_message_diastolic_pressure_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_mean_arterial_pressure_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43010,11 +46476,13 @@ fn blood_pressure_message_mean_arterial_pressure_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_map_3_sample_mean_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43035,11 +46503,13 @@ fn blood_pressure_message_map_3_sample_mean_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_map_morning_values_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43060,11 +46530,13 @@ fn blood_pressure_message_map_morning_values_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_map_evening_values_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43085,11 +46557,13 @@ fn blood_pressure_message_map_evening_values_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43110,11 +46584,13 @@ fn blood_pressure_message_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_heart_rate_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43135,11 +46611,13 @@ fn blood_pressure_message_heart_rate_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_status_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43160,11 +46638,13 @@ fn blood_pressure_message_status_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_user_profile_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43185,11 +46665,13 @@ fn blood_pressure_message_user_profile_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn blood_pressure_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43210,12 +46692,14 @@ fn blood_pressure_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_info_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -43227,6 +46711,7 @@ fn monitoring_info_message(
                 fields.push(monitoring_info_message_local_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43239,6 +46724,7 @@ fn monitoring_info_message(
                 fields.push(monitoring_info_message_activity_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43252,6 +46738,7 @@ fn monitoring_info_message(
                 fields.push(monitoring_info_message_cycles_to_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5000.000000,
@@ -43265,6 +46752,7 @@ fn monitoring_info_message(
                 fields.push(monitoring_info_message_cycles_to_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     5000.000000,
@@ -43277,6 +46765,7 @@ fn monitoring_info_message(
                 fields.push(monitoring_info_message_resting_metabolic_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43289,6 +46778,7 @@ fn monitoring_info_message(
                 fields.push(monitoring_info_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43305,6 +46795,7 @@ fn monitoring_info_message(
 fn monitoring_info_message_local_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43325,11 +46816,13 @@ fn monitoring_info_message_local_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_info_message_activity_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43350,11 +46843,13 @@ fn monitoring_info_message_activity_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_info_message_cycles_to_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43375,11 +46870,13 @@ fn monitoring_info_message_cycles_to_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_info_message_cycles_to_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43400,11 +46897,13 @@ fn monitoring_info_message_cycles_to_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_info_message_resting_metabolic_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43425,11 +46924,13 @@ fn monitoring_info_message_resting_metabolic_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_info_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43450,12 +46951,14 @@ fn monitoring_info_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -43467,6 +46970,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_device_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43480,6 +46984,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43493,6 +46998,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_distance_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -43513,6 +47019,7 @@ fn monitoring_message(
                     fields.push(monitoring_message_steps_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -43530,6 +47037,7 @@ fn monitoring_message(
                     fields.push(monitoring_message_steps_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         1.000000,
@@ -43547,6 +47055,7 @@ fn monitoring_message(
                     fields.push(monitoring_message_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         2.000000,
@@ -43564,6 +47073,7 @@ fn monitoring_message(
                     fields.push(monitoring_message_strokes_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         2.000000,
@@ -43575,6 +47085,7 @@ fn monitoring_message(
                     fields.push(monitoring_message_cycles_field(
                         mesg_num,
                         accumlators,
+                        options,
                         data_map,
                         false,
                         2.000000,
@@ -43588,6 +47099,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_active_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -43600,6 +47112,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_activity_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43612,6 +47125,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_activity_subtype_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43624,6 +47138,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_activity_level_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43636,6 +47151,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_distance_16_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43648,6 +47164,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_cycles_16_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43660,6 +47177,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_active_time_16_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43673,6 +47191,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_local_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43686,6 +47205,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_temperature_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -43699,6 +47219,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_temperature_min_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -43712,6 +47233,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_temperature_max_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     100.000000,
@@ -43725,6 +47247,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_activity_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43737,6 +47260,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_active_calories_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43759,6 +47283,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_activity_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43770,6 +47295,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_intensity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43782,6 +47308,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_timestamp_min_8_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43794,6 +47321,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_timestamp_16_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43806,6 +47334,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_heart_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43818,6 +47347,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_intensity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     10.000000,
@@ -43830,6 +47360,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_duration_min_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43842,6 +47373,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_duration_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43854,6 +47386,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_ascent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -43866,6 +47399,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_descent_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -43878,6 +47412,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_moderate_activity_minutes_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43890,6 +47425,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_vigorous_activity_minutes_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43903,6 +47439,7 @@ fn monitoring_message(
                 fields.push(monitoring_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -43919,6 +47456,7 @@ fn monitoring_message(
 fn monitoring_message_device_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43939,11 +47477,13 @@ fn monitoring_message_device_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43964,11 +47504,13 @@ fn monitoring_message_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_distance_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -43989,11 +47531,13 @@ fn monitoring_message_distance_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_cycles_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44014,11 +47558,13 @@ fn monitoring_message_cycles_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_steps_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44039,11 +47585,13 @@ fn monitoring_message_steps_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_strokes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44064,11 +47612,13 @@ fn monitoring_message_strokes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_active_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44089,11 +47639,13 @@ fn monitoring_message_active_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_activity_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44114,11 +47666,13 @@ fn monitoring_message_activity_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_activity_subtype_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44139,11 +47693,13 @@ fn monitoring_message_activity_subtype_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_activity_level_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44164,11 +47720,13 @@ fn monitoring_message_activity_level_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_distance_16_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44189,11 +47747,13 @@ fn monitoring_message_distance_16_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_cycles_16_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44214,11 +47774,13 @@ fn monitoring_message_cycles_16_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_active_time_16_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44239,11 +47801,13 @@ fn monitoring_message_active_time_16_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_local_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44264,11 +47828,13 @@ fn monitoring_message_local_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_temperature_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44289,11 +47855,13 @@ fn monitoring_message_temperature_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_temperature_min_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44314,11 +47882,13 @@ fn monitoring_message_temperature_min_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_temperature_max_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44339,11 +47909,13 @@ fn monitoring_message_temperature_max_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_activity_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44364,11 +47936,13 @@ fn monitoring_message_activity_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_active_calories_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44389,11 +47963,13 @@ fn monitoring_message_active_calories_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_timestamp_min_8_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44414,11 +47990,13 @@ fn monitoring_message_timestamp_min_8_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_timestamp_16_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44439,11 +48017,13 @@ fn monitoring_message_timestamp_16_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_heart_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44464,11 +48044,13 @@ fn monitoring_message_heart_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_intensity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44489,11 +48071,13 @@ fn monitoring_message_intensity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_duration_min_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44514,11 +48098,13 @@ fn monitoring_message_duration_min_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_duration_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44539,11 +48125,13 @@ fn monitoring_message_duration_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_ascent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44564,11 +48152,13 @@ fn monitoring_message_ascent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_descent_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44589,11 +48179,13 @@ fn monitoring_message_descent_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_moderate_activity_minutes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44614,11 +48206,13 @@ fn monitoring_message_moderate_activity_minutes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_vigorous_activity_minutes_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44639,11 +48233,13 @@ fn monitoring_message_vigorous_activity_minutes_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn monitoring_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44664,12 +48260,14 @@ fn monitoring_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hr_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -44680,6 +48278,7 @@ fn hr_message(
                 fields.push(hr_message_fractional_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     32768.000000,
@@ -44695,6 +48294,7 @@ fn hr_message(
                 fields.push(hr_message_fractional_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     256.000000,
@@ -44707,6 +48307,7 @@ fn hr_message(
                 fields.push(hr_message_filtered_bpm_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -44719,6 +48320,7 @@ fn hr_message(
                 fields.push(hr_message_event_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1024.000000,
@@ -44756,6 +48358,7 @@ fn hr_message(
                 fields.push(hr_message_event_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     true,
                     1024.000000,
@@ -44768,6 +48371,7 @@ fn hr_message(
                 fields.push(hr_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -44784,6 +48388,7 @@ fn hr_message(
 fn hr_message_fractional_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44804,11 +48409,13 @@ fn hr_message_fractional_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hr_message_filtered_bpm_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44829,11 +48436,13 @@ fn hr_message_filtered_bpm_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hr_message_event_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44854,11 +48463,13 @@ fn hr_message_event_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn hr_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44879,6 +48490,7 @@ fn hr_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Value from 1 to 100 calculated by FirstBeat
@@ -44886,6 +48498,7 @@ fn stress_level_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -44896,6 +48509,7 @@ fn stress_level_message(
                 fields.push(stress_level_message_stress_level_value_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -44909,6 +48523,7 @@ fn stress_level_message(
                 fields.push(stress_level_message_stress_level_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -44925,6 +48540,7 @@ fn stress_level_message(
 fn stress_level_message_stress_level_value_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44945,11 +48561,13 @@ fn stress_level_message_stress_level_value_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn stress_level_message_stress_level_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -44970,12 +48588,14 @@ fn stress_level_message_stress_level_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn memo_glob_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -44987,6 +48607,7 @@ fn memo_glob_message(
                 fields.push(memo_glob_message_memo_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45000,6 +48621,7 @@ fn memo_glob_message(
                 fields.push(memo_glob_message_mesg_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45013,6 +48635,7 @@ fn memo_glob_message(
                 fields.push(memo_glob_message_parent_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45026,6 +48649,7 @@ fn memo_glob_message(
                 fields.push(memo_glob_message_field_num_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45039,6 +48663,7 @@ fn memo_glob_message(
                 fields.push(memo_glob_message_data_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45052,6 +48677,7 @@ fn memo_glob_message(
                 fields.push(memo_glob_message_part_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45068,6 +48694,7 @@ fn memo_glob_message(
 fn memo_glob_message_memo_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45080,11 +48707,21 @@ fn memo_glob_message_memo_field(
     } else {
         value
     };
-    data_field_with_info(0, "memo", FieldDataType::Byte, scale, offset, units, value)
+    data_field_with_info(
+        0,
+        "memo",
+        FieldDataType::Byte,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn memo_glob_message_mesg_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45105,11 +48742,13 @@ fn memo_glob_message_mesg_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn memo_glob_message_parent_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45130,11 +48769,13 @@ fn memo_glob_message_parent_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn memo_glob_message_field_num_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45155,11 +48796,13 @@ fn memo_glob_message_field_num_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn memo_glob_message_data_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45180,11 +48823,13 @@ fn memo_glob_message_data_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn memo_glob_message_part_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45205,12 +48850,14 @@ fn memo_glob_message_part_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_channel_id_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -45221,6 +48868,7 @@ fn ant_channel_id_message(
                 fields.push(ant_channel_id_message_channel_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45233,6 +48881,7 @@ fn ant_channel_id_message(
                 fields.push(ant_channel_id_message_device_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45245,6 +48894,7 @@ fn ant_channel_id_message(
                 fields.push(ant_channel_id_message_device_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45257,6 +48907,7 @@ fn ant_channel_id_message(
                 fields.push(ant_channel_id_message_transmission_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45269,6 +48920,7 @@ fn ant_channel_id_message(
                 fields.push(ant_channel_id_message_device_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45285,6 +48937,7 @@ fn ant_channel_id_message(
 fn ant_channel_id_message_channel_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45305,11 +48958,13 @@ fn ant_channel_id_message_channel_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_channel_id_message_device_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45330,11 +48985,13 @@ fn ant_channel_id_message_device_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_channel_id_message_device_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45355,11 +49012,13 @@ fn ant_channel_id_message_device_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_channel_id_message_transmission_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45380,11 +49039,13 @@ fn ant_channel_id_message_transmission_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_channel_id_message_device_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45405,12 +49066,14 @@ fn ant_channel_id_message_device_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_rx_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -45421,6 +49084,7 @@ fn ant_rx_message(
                 fields.push(ant_rx_message_fractional_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     32768.000000,
@@ -45433,6 +49097,7 @@ fn ant_rx_message(
                 fields.push(ant_rx_message_mesg_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45457,6 +49122,7 @@ fn ant_rx_message(
                 fields.push(ant_rx_message_channel_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45471,6 +49137,7 @@ fn ant_rx_message(
                 fields.push(ant_rx_message_data_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45483,6 +49150,7 @@ fn ant_rx_message(
                 fields.push(ant_rx_message_channel_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45495,6 +49163,7 @@ fn ant_rx_message(
                 fields.push(ant_rx_message_data_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45507,6 +49176,7 @@ fn ant_rx_message(
                 fields.push(ant_rx_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45523,6 +49193,7 @@ fn ant_rx_message(
 fn ant_rx_message_fractional_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45543,11 +49214,13 @@ fn ant_rx_message_fractional_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_rx_message_mesg_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45568,11 +49241,13 @@ fn ant_rx_message_mesg_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_rx_message_channel_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45593,11 +49268,13 @@ fn ant_rx_message_channel_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_rx_message_data_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45610,11 +49287,21 @@ fn ant_rx_message_data_field(
     } else {
         value
     };
-    data_field_with_info(4, "data", FieldDataType::Byte, scale, offset, units, value)
+    data_field_with_info(
+        4,
+        "data",
+        FieldDataType::Byte,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn ant_rx_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45635,12 +49322,14 @@ fn ant_rx_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_tx_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -45651,6 +49340,7 @@ fn ant_tx_message(
                 fields.push(ant_tx_message_fractional_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     32768.000000,
@@ -45663,6 +49353,7 @@ fn ant_tx_message(
                 fields.push(ant_tx_message_mesg_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45687,6 +49378,7 @@ fn ant_tx_message(
                 fields.push(ant_tx_message_channel_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45701,6 +49393,7 @@ fn ant_tx_message(
                 fields.push(ant_tx_message_data_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45713,6 +49406,7 @@ fn ant_tx_message(
                 fields.push(ant_tx_message_channel_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45725,6 +49419,7 @@ fn ant_tx_message(
                 fields.push(ant_tx_message_data_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45737,6 +49432,7 @@ fn ant_tx_message(
                 fields.push(ant_tx_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45753,6 +49449,7 @@ fn ant_tx_message(
 fn ant_tx_message_fractional_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45773,11 +49470,13 @@ fn ant_tx_message_fractional_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_tx_message_mesg_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45798,11 +49497,13 @@ fn ant_tx_message_mesg_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_tx_message_channel_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45823,11 +49524,13 @@ fn ant_tx_message_channel_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn ant_tx_message_data_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45840,11 +49543,21 @@ fn ant_tx_message_data_field(
     } else {
         value
     };
-    data_field_with_info(4, "data", FieldDataType::Byte, scale, offset, units, value)
+    data_field_with_info(
+        4,
+        "data",
+        FieldDataType::Byte,
+        scale,
+        offset,
+        units,
+        value,
+        options,
+    )
 }
 fn ant_tx_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45865,12 +49578,14 @@ fn ant_tx_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_screen_configuration_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -45881,6 +49596,7 @@ fn exd_screen_configuration_message(
                 fields.push(exd_screen_configuration_message_screen_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45894,6 +49610,7 @@ fn exd_screen_configuration_message(
                 fields.push(exd_screen_configuration_message_field_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45906,6 +49623,7 @@ fn exd_screen_configuration_message(
                 fields.push(exd_screen_configuration_message_layout_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45918,6 +49636,7 @@ fn exd_screen_configuration_message(
                 fields.push(exd_screen_configuration_message_screen_enabled_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -45934,6 +49653,7 @@ fn exd_screen_configuration_message(
 fn exd_screen_configuration_message_screen_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45954,11 +49674,13 @@ fn exd_screen_configuration_message_screen_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_screen_configuration_message_field_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -45979,11 +49701,13 @@ fn exd_screen_configuration_message_field_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_screen_configuration_message_layout_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46004,11 +49728,13 @@ fn exd_screen_configuration_message_layout_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_screen_configuration_message_screen_enabled_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46029,12 +49755,14 @@ fn exd_screen_configuration_message_screen_enabled_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_field_configuration_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -46045,6 +49773,7 @@ fn exd_data_field_configuration_message(
                 fields.push(exd_data_field_configuration_message_screen_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46061,6 +49790,7 @@ fn exd_data_field_configuration_message(
                 fields.push(exd_data_field_configuration_message_field_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46072,6 +49802,7 @@ fn exd_data_field_configuration_message(
                 fields.push(exd_data_field_configuration_message_concept_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46084,6 +49815,7 @@ fn exd_data_field_configuration_message(
                 fields.push(exd_data_field_configuration_message_field_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46096,6 +49828,7 @@ fn exd_data_field_configuration_message(
                 fields.push(exd_data_field_configuration_message_concept_count_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46108,6 +49841,7 @@ fn exd_data_field_configuration_message(
                 fields.push(exd_data_field_configuration_message_display_type_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46120,6 +49854,7 @@ fn exd_data_field_configuration_message(
                 fields.push(exd_data_field_configuration_message_title_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46136,6 +49871,7 @@ fn exd_data_field_configuration_message(
 fn exd_data_field_configuration_message_screen_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46156,11 +49892,13 @@ fn exd_data_field_configuration_message_screen_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_field_configuration_message_field_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46181,11 +49919,13 @@ fn exd_data_field_configuration_message_field_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_field_configuration_message_concept_count_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46206,11 +49946,13 @@ fn exd_data_field_configuration_message_concept_count_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_field_configuration_message_display_type_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46231,11 +49973,13 @@ fn exd_data_field_configuration_message_display_type_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_field_configuration_message_title_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46256,12 +50000,14 @@ fn exd_data_field_configuration_message_title_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -46272,6 +50018,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_screen_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46288,6 +50035,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_field_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46299,6 +50047,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_concept_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46311,6 +50060,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_field_id_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46323,6 +50073,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_concept_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46335,6 +50086,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_data_page_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46347,6 +50099,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_concept_key_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46359,6 +50112,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_scaling_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46371,6 +50125,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_data_units_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46383,6 +50138,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_qualifier_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46395,6 +50151,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_descriptor_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46407,6 +50164,7 @@ fn exd_data_concept_configuration_message(
                 fields.push(exd_data_concept_configuration_message_is_signed_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46423,6 +50181,7 @@ fn exd_data_concept_configuration_message(
 fn exd_data_concept_configuration_message_screen_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46443,11 +50202,13 @@ fn exd_data_concept_configuration_message_screen_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_field_id_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46468,11 +50229,13 @@ fn exd_data_concept_configuration_message_field_id_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_concept_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46493,11 +50256,13 @@ fn exd_data_concept_configuration_message_concept_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_data_page_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46518,11 +50283,13 @@ fn exd_data_concept_configuration_message_data_page_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_concept_key_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46543,11 +50310,13 @@ fn exd_data_concept_configuration_message_concept_key_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_scaling_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46568,11 +50337,13 @@ fn exd_data_concept_configuration_message_scaling_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_data_units_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46593,11 +50364,13 @@ fn exd_data_concept_configuration_message_data_units_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_qualifier_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46618,11 +50391,13 @@ fn exd_data_concept_configuration_message_qualifier_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_descriptor_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46643,11 +50418,13 @@ fn exd_data_concept_configuration_message_descriptor_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn exd_data_concept_configuration_message_is_signed_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46668,12 +50445,14 @@ fn exd_data_concept_configuration_message_is_signed_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -46684,6 +50463,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_reference_mesg_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46696,6 +50476,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_reference_index_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46709,6 +50490,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_avg_depth_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46722,6 +50504,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_max_depth_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46735,6 +50518,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_surface_interval_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46747,6 +50531,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_start_cns_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46759,6 +50544,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_end_cns_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46771,6 +50557,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_start_n2_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46783,6 +50570,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_end_n2_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46795,6 +50583,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_o2_toxicity_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46807,6 +50596,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_dive_number_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46819,6 +50609,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_bottom_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46832,6 +50623,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_avg_ascent_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46845,6 +50637,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_avg_descent_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46858,6 +50651,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_max_ascent_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46871,6 +50665,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_max_descent_rate_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46884,6 +50679,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_hang_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -46896,6 +50692,7 @@ fn dive_summary_message(
                 fields.push(dive_summary_message_timestamp_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1.000000,
@@ -46912,6 +50709,7 @@ fn dive_summary_message(
 fn dive_summary_message_reference_mesg_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46932,11 +50730,13 @@ fn dive_summary_message_reference_mesg_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_reference_index_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46957,11 +50757,13 @@ fn dive_summary_message_reference_index_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_avg_depth_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -46982,11 +50784,13 @@ fn dive_summary_message_avg_depth_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_max_depth_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47007,11 +50811,13 @@ fn dive_summary_message_max_depth_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_surface_interval_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47032,11 +50838,13 @@ fn dive_summary_message_surface_interval_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_start_cns_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47057,11 +50865,13 @@ fn dive_summary_message_start_cns_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_end_cns_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47082,11 +50892,13 @@ fn dive_summary_message_end_cns_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_start_n2_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47107,11 +50919,13 @@ fn dive_summary_message_start_n2_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_end_n2_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47132,11 +50946,13 @@ fn dive_summary_message_end_n2_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_o2_toxicity_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47157,11 +50973,13 @@ fn dive_summary_message_o2_toxicity_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_dive_number_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47182,11 +51000,13 @@ fn dive_summary_message_dive_number_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_bottom_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47207,11 +51027,13 @@ fn dive_summary_message_bottom_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_avg_ascent_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47232,11 +51054,13 @@ fn dive_summary_message_avg_ascent_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_avg_descent_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47257,11 +51081,13 @@ fn dive_summary_message_avg_descent_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_max_ascent_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47282,11 +51108,13 @@ fn dive_summary_message_max_ascent_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_max_descent_rate_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47307,11 +51135,13 @@ fn dive_summary_message_max_descent_rate_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_hang_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47332,11 +51162,13 @@ fn dive_summary_message_hang_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 fn dive_summary_message_timestamp_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47357,6 +51189,7 @@ fn dive_summary_message_timestamp_field(
         offset,
         units,
         value,
+        options,
     )
 }
 /// Heart rate variability
@@ -47364,6 +51197,7 @@ fn hrv_message(
     mesg_num: MesgNum,
     data_map: &mut HashMap<u8, Value>,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
 ) -> Result<Vec<FitDataField>> {
     let mut fields = Vec::new();
     let mut entries: VecDeque<(u8, Value)> =
@@ -47375,6 +51209,7 @@ fn hrv_message(
                 fields.push(hrv_message_time_field(
                     mesg_num,
                     accumlators,
+                    options,
                     data_map,
                     false,
                     1000.000000,
@@ -47391,6 +51226,7 @@ fn hrv_message(
 fn hrv_message_time_field(
     mesg_num: MesgNum,
     accumlators: &mut HashMap<u32, Value>,
+    options: &HashSet<DecodeOption>,
     data_map: &HashMap<u8, Value>,
     accumulate: bool,
     scale: f64,
@@ -47411,6 +51247,7 @@ fn hrv_message_time_field(
         offset,
         units,
         value,
+        options,
     )
 }
 
@@ -47428,112 +51265,141 @@ impl MesgNum {
         self,
         data_map: &mut HashMap<u8, Value>,
         accumlators: &mut HashMap<u32, Value>,
+        options: &HashSet<DecodeOption>,
     ) -> Result<Vec<FitDataField>> {
         match self {
-            MesgNum::FileId => file_id_message(self, data_map, accumlators),
-            MesgNum::FileCreator => file_creator_message(self, data_map, accumlators),
+            MesgNum::FileId => file_id_message(self, data_map, accumlators, options),
+            MesgNum::FileCreator => file_creator_message(self, data_map, accumlators, options),
             MesgNum::TimestampCorrelation => {
-                timestamp_correlation_message(self, data_map, accumlators)
+                timestamp_correlation_message(self, data_map, accumlators, options)
             }
-            MesgNum::Software => software_message(self, data_map, accumlators),
-            MesgNum::SlaveDevice => slave_device_message(self, data_map, accumlators),
-            MesgNum::Capabilities => capabilities_message(self, data_map, accumlators),
-            MesgNum::FileCapabilities => file_capabilities_message(self, data_map, accumlators),
-            MesgNum::MesgCapabilities => mesg_capabilities_message(self, data_map, accumlators),
-            MesgNum::FieldCapabilities => field_capabilities_message(self, data_map, accumlators),
-            MesgNum::DeviceSettings => device_settings_message(self, data_map, accumlators),
-            MesgNum::UserProfile => user_profile_message(self, data_map, accumlators),
-            MesgNum::HrmProfile => hrm_profile_message(self, data_map, accumlators),
-            MesgNum::SdmProfile => sdm_profile_message(self, data_map, accumlators),
-            MesgNum::BikeProfile => bike_profile_message(self, data_map, accumlators),
-            MesgNum::Connectivity => connectivity_message(self, data_map, accumlators),
-            MesgNum::WatchfaceSettings => watchface_settings_message(self, data_map, accumlators),
-            MesgNum::OhrSettings => ohr_settings_message(self, data_map, accumlators),
-            MesgNum::ZonesTarget => zones_target_message(self, data_map, accumlators),
-            MesgNum::Sport => sport_message(self, data_map, accumlators),
-            MesgNum::HrZone => hr_zone_message(self, data_map, accumlators),
-            MesgNum::SpeedZone => speed_zone_message(self, data_map, accumlators),
-            MesgNum::CadenceZone => cadence_zone_message(self, data_map, accumlators),
-            MesgNum::PowerZone => power_zone_message(self, data_map, accumlators),
-            MesgNum::MetZone => met_zone_message(self, data_map, accumlators),
-            MesgNum::DiveSettings => dive_settings_message(self, data_map, accumlators),
-            MesgNum::DiveAlarm => dive_alarm_message(self, data_map, accumlators),
-            MesgNum::DiveGas => dive_gas_message(self, data_map, accumlators),
-            MesgNum::Goal => goal_message(self, data_map, accumlators),
-            MesgNum::Activity => activity_message(self, data_map, accumlators),
-            MesgNum::Session => session_message(self, data_map, accumlators),
-            MesgNum::Lap => lap_message(self, data_map, accumlators),
-            MesgNum::Length => length_message(self, data_map, accumlators),
-            MesgNum::Record => record_message(self, data_map, accumlators),
-            MesgNum::Event => event_message(self, data_map, accumlators),
-            MesgNum::DeviceInfo => device_info_message(self, data_map, accumlators),
+            MesgNum::Software => software_message(self, data_map, accumlators, options),
+            MesgNum::SlaveDevice => slave_device_message(self, data_map, accumlators, options),
+            MesgNum::Capabilities => capabilities_message(self, data_map, accumlators, options),
+            MesgNum::FileCapabilities => {
+                file_capabilities_message(self, data_map, accumlators, options)
+            }
+            MesgNum::MesgCapabilities => {
+                mesg_capabilities_message(self, data_map, accumlators, options)
+            }
+            MesgNum::FieldCapabilities => {
+                field_capabilities_message(self, data_map, accumlators, options)
+            }
+            MesgNum::DeviceSettings => {
+                device_settings_message(self, data_map, accumlators, options)
+            }
+            MesgNum::UserProfile => user_profile_message(self, data_map, accumlators, options),
+            MesgNum::HrmProfile => hrm_profile_message(self, data_map, accumlators, options),
+            MesgNum::SdmProfile => sdm_profile_message(self, data_map, accumlators, options),
+            MesgNum::BikeProfile => bike_profile_message(self, data_map, accumlators, options),
+            MesgNum::Connectivity => connectivity_message(self, data_map, accumlators, options),
+            MesgNum::WatchfaceSettings => {
+                watchface_settings_message(self, data_map, accumlators, options)
+            }
+            MesgNum::OhrSettings => ohr_settings_message(self, data_map, accumlators, options),
+            MesgNum::ZonesTarget => zones_target_message(self, data_map, accumlators, options),
+            MesgNum::Sport => sport_message(self, data_map, accumlators, options),
+            MesgNum::HrZone => hr_zone_message(self, data_map, accumlators, options),
+            MesgNum::SpeedZone => speed_zone_message(self, data_map, accumlators, options),
+            MesgNum::CadenceZone => cadence_zone_message(self, data_map, accumlators, options),
+            MesgNum::PowerZone => power_zone_message(self, data_map, accumlators, options),
+            MesgNum::MetZone => met_zone_message(self, data_map, accumlators, options),
+            MesgNum::DiveSettings => dive_settings_message(self, data_map, accumlators, options),
+            MesgNum::DiveAlarm => dive_alarm_message(self, data_map, accumlators, options),
+            MesgNum::DiveGas => dive_gas_message(self, data_map, accumlators, options),
+            MesgNum::Goal => goal_message(self, data_map, accumlators, options),
+            MesgNum::Activity => activity_message(self, data_map, accumlators, options),
+            MesgNum::Session => session_message(self, data_map, accumlators, options),
+            MesgNum::Lap => lap_message(self, data_map, accumlators, options),
+            MesgNum::Length => length_message(self, data_map, accumlators, options),
+            MesgNum::Record => record_message(self, data_map, accumlators, options),
+            MesgNum::Event => event_message(self, data_map, accumlators, options),
+            MesgNum::DeviceInfo => device_info_message(self, data_map, accumlators, options),
             MesgNum::DeviceAuxBatteryInfo => {
-                device_aux_battery_info_message(self, data_map, accumlators)
+                device_aux_battery_info_message(self, data_map, accumlators, options)
             }
-            MesgNum::TrainingFile => training_file_message(self, data_map, accumlators),
-            MesgNum::WeatherConditions => weather_conditions_message(self, data_map, accumlators),
-            MesgNum::WeatherAlert => weather_alert_message(self, data_map, accumlators),
-            MesgNum::GpsMetadata => gps_metadata_message(self, data_map, accumlators),
-            MesgNum::CameraEvent => camera_event_message(self, data_map, accumlators),
-            MesgNum::GyroscopeData => gyroscope_data_message(self, data_map, accumlators),
-            MesgNum::AccelerometerData => accelerometer_data_message(self, data_map, accumlators),
-            MesgNum::MagnetometerData => magnetometer_data_message(self, data_map, accumlators),
-            MesgNum::BarometerData => barometer_data_message(self, data_map, accumlators),
+            MesgNum::TrainingFile => training_file_message(self, data_map, accumlators, options),
+            MesgNum::WeatherConditions => {
+                weather_conditions_message(self, data_map, accumlators, options)
+            }
+            MesgNum::WeatherAlert => weather_alert_message(self, data_map, accumlators, options),
+            MesgNum::GpsMetadata => gps_metadata_message(self, data_map, accumlators, options),
+            MesgNum::CameraEvent => camera_event_message(self, data_map, accumlators, options),
+            MesgNum::GyroscopeData => gyroscope_data_message(self, data_map, accumlators, options),
+            MesgNum::AccelerometerData => {
+                accelerometer_data_message(self, data_map, accumlators, options)
+            }
+            MesgNum::MagnetometerData => {
+                magnetometer_data_message(self, data_map, accumlators, options)
+            }
+            MesgNum::BarometerData => barometer_data_message(self, data_map, accumlators, options),
             MesgNum::ThreeDSensorCalibration => {
-                three_d_sensor_calibration_message(self, data_map, accumlators)
+                three_d_sensor_calibration_message(self, data_map, accumlators, options)
             }
             MesgNum::OneDSensorCalibration => {
-                one_d_sensor_calibration_message(self, data_map, accumlators)
+                one_d_sensor_calibration_message(self, data_map, accumlators, options)
             }
-            MesgNum::VideoFrame => video_frame_message(self, data_map, accumlators),
-            MesgNum::ObdiiData => obdii_data_message(self, data_map, accumlators),
-            MesgNum::NmeaSentence => nmea_sentence_message(self, data_map, accumlators),
-            MesgNum::AviationAttitude => aviation_attitude_message(self, data_map, accumlators),
-            MesgNum::Video => video_message(self, data_map, accumlators),
-            MesgNum::VideoTitle => video_title_message(self, data_map, accumlators),
-            MesgNum::VideoDescription => video_description_message(self, data_map, accumlators),
-            MesgNum::VideoClip => video_clip_message(self, data_map, accumlators),
-            MesgNum::Set => set_message(self, data_map, accumlators),
-            MesgNum::Jump => jump_message(self, data_map, accumlators),
-            MesgNum::ClimbPro => climb_pro_message(self, data_map, accumlators),
-            MesgNum::FieldDescription => field_description_message(self, data_map, accumlators),
-            MesgNum::DeveloperDataId => developer_data_id_message(self, data_map, accumlators),
-            MesgNum::Course => course_message(self, data_map, accumlators),
-            MesgNum::CoursePoint => course_point_message(self, data_map, accumlators),
-            MesgNum::SegmentId => segment_id_message(self, data_map, accumlators),
+            MesgNum::VideoFrame => video_frame_message(self, data_map, accumlators, options),
+            MesgNum::ObdiiData => obdii_data_message(self, data_map, accumlators, options),
+            MesgNum::NmeaSentence => nmea_sentence_message(self, data_map, accumlators, options),
+            MesgNum::AviationAttitude => {
+                aviation_attitude_message(self, data_map, accumlators, options)
+            }
+            MesgNum::Video => video_message(self, data_map, accumlators, options),
+            MesgNum::VideoTitle => video_title_message(self, data_map, accumlators, options),
+            MesgNum::VideoDescription => {
+                video_description_message(self, data_map, accumlators, options)
+            }
+            MesgNum::VideoClip => video_clip_message(self, data_map, accumlators, options),
+            MesgNum::Set => set_message(self, data_map, accumlators, options),
+            MesgNum::Jump => jump_message(self, data_map, accumlators, options),
+            MesgNum::ClimbPro => climb_pro_message(self, data_map, accumlators, options),
+            MesgNum::FieldDescription => {
+                field_description_message(self, data_map, accumlators, options)
+            }
+            MesgNum::DeveloperDataId => {
+                developer_data_id_message(self, data_map, accumlators, options)
+            }
+            MesgNum::Course => course_message(self, data_map, accumlators, options),
+            MesgNum::CoursePoint => course_point_message(self, data_map, accumlators, options),
+            MesgNum::SegmentId => segment_id_message(self, data_map, accumlators, options),
             MesgNum::SegmentLeaderboardEntry => {
-                segment_leaderboard_entry_message(self, data_map, accumlators)
+                segment_leaderboard_entry_message(self, data_map, accumlators, options)
             }
-            MesgNum::SegmentPoint => segment_point_message(self, data_map, accumlators),
-            MesgNum::SegmentLap => segment_lap_message(self, data_map, accumlators),
-            MesgNum::SegmentFile => segment_file_message(self, data_map, accumlators),
-            MesgNum::Workout => workout_message(self, data_map, accumlators),
-            MesgNum::WorkoutSession => workout_session_message(self, data_map, accumlators),
-            MesgNum::WorkoutStep => workout_step_message(self, data_map, accumlators),
-            MesgNum::ExerciseTitle => exercise_title_message(self, data_map, accumlators),
-            MesgNum::Schedule => schedule_message(self, data_map, accumlators),
-            MesgNum::Totals => totals_message(self, data_map, accumlators),
-            MesgNum::WeightScale => weight_scale_message(self, data_map, accumlators),
-            MesgNum::BloodPressure => blood_pressure_message(self, data_map, accumlators),
-            MesgNum::MonitoringInfo => monitoring_info_message(self, data_map, accumlators),
-            MesgNum::Monitoring => monitoring_message(self, data_map, accumlators),
-            MesgNum::Hr => hr_message(self, data_map, accumlators),
-            MesgNum::StressLevel => stress_level_message(self, data_map, accumlators),
-            MesgNum::MemoGlob => memo_glob_message(self, data_map, accumlators),
-            MesgNum::AntChannelId => ant_channel_id_message(self, data_map, accumlators),
-            MesgNum::AntRx => ant_rx_message(self, data_map, accumlators),
-            MesgNum::AntTx => ant_tx_message(self, data_map, accumlators),
+            MesgNum::SegmentPoint => segment_point_message(self, data_map, accumlators, options),
+            MesgNum::SegmentLap => segment_lap_message(self, data_map, accumlators, options),
+            MesgNum::SegmentFile => segment_file_message(self, data_map, accumlators, options),
+            MesgNum::Workout => workout_message(self, data_map, accumlators, options),
+            MesgNum::WorkoutSession => {
+                workout_session_message(self, data_map, accumlators, options)
+            }
+            MesgNum::WorkoutStep => workout_step_message(self, data_map, accumlators, options),
+            MesgNum::ExerciseTitle => exercise_title_message(self, data_map, accumlators, options),
+            MesgNum::Schedule => schedule_message(self, data_map, accumlators, options),
+            MesgNum::Totals => totals_message(self, data_map, accumlators, options),
+            MesgNum::WeightScale => weight_scale_message(self, data_map, accumlators, options),
+            MesgNum::BloodPressure => blood_pressure_message(self, data_map, accumlators, options),
+            MesgNum::MonitoringInfo => {
+                monitoring_info_message(self, data_map, accumlators, options)
+            }
+            MesgNum::Monitoring => monitoring_message(self, data_map, accumlators, options),
+            MesgNum::Hr => hr_message(self, data_map, accumlators, options),
+            MesgNum::StressLevel => stress_level_message(self, data_map, accumlators, options),
+            MesgNum::MemoGlob => memo_glob_message(self, data_map, accumlators, options),
+            MesgNum::AntChannelId => ant_channel_id_message(self, data_map, accumlators, options),
+            MesgNum::AntRx => ant_rx_message(self, data_map, accumlators, options),
+            MesgNum::AntTx => ant_tx_message(self, data_map, accumlators, options),
             MesgNum::ExdScreenConfiguration => {
-                exd_screen_configuration_message(self, data_map, accumlators)
+                exd_screen_configuration_message(self, data_map, accumlators, options)
             }
             MesgNum::ExdDataFieldConfiguration => {
-                exd_data_field_configuration_message(self, data_map, accumlators)
+                exd_data_field_configuration_message(self, data_map, accumlators, options)
             }
             MesgNum::ExdDataConceptConfiguration => {
-                exd_data_concept_configuration_message(self, data_map, accumlators)
+                exd_data_concept_configuration_message(self, data_map, accumlators, options)
             }
-            MesgNum::DiveSummary => dive_summary_message(self, data_map, accumlators),
-            MesgNum::Hrv => hrv_message(self, data_map, accumlators),
+            MesgNum::DiveSummary => dive_summary_message(self, data_map, accumlators, options),
+            MesgNum::Hrv => hrv_message(self, data_map, accumlators, options),
             _ => unknown_message(data_map),
         }
     }

--- a/fitparser/src/profile/decode.rs
+++ b/fitparser/src/profile/decode.rs
@@ -313,9 +313,14 @@ fn file_id_message_favero_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "favero_product"
+    };
     data_field_with_info(
         2,
-        "favero_product",
+        name,
         FieldDataType::FaveroProduct,
         scale,
         offset,
@@ -340,9 +345,14 @@ fn file_id_message_garmin_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "garmin_product"
+    };
     data_field_with_info(
         2,
-        "garmin_product",
+        name,
         FieldDataType::GarminProduct,
         scale,
         offset,
@@ -1216,9 +1226,14 @@ fn slave_device_message_favero_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "favero_product"
+    };
     data_field_with_info(
         1,
-        "favero_product",
+        name,
         FieldDataType::FaveroProduct,
         scale,
         offset,
@@ -1243,9 +1258,14 @@ fn slave_device_message_garmin_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "garmin_product"
+    };
     data_field_with_info(
         1,
-        "garmin_product",
+        name,
         FieldDataType::GarminProduct,
         scale,
         offset,
@@ -1961,9 +1981,14 @@ fn mesg_capabilities_message_num_per_file_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "count"
+    } else {
+        "num_per_file"
+    };
     data_field_with_info(
         3,
-        "num_per_file",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -1988,9 +2013,14 @@ fn mesg_capabilities_message_max_per_file_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "count"
+    } else {
+        "max_per_file"
+    };
     data_field_with_info(
         3,
-        "max_per_file",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -2015,9 +2045,14 @@ fn mesg_capabilities_message_max_per_file_type_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "count"
+    } else {
+        "max_per_file_type"
+    };
     data_field_with_info(
         3,
-        "max_per_file_type",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -7039,9 +7074,14 @@ fn watchface_settings_message_digital_layout_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "layout"
+    } else {
+        "digital_layout"
+    };
     data_field_with_info(
         1,
-        "digital_layout",
+        name,
         FieldDataType::DigitalWatchfaceLayout,
         scale,
         offset,
@@ -7066,9 +7106,14 @@ fn watchface_settings_message_analog_layout_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "layout"
+    } else {
+        "analog_layout"
+    };
     data_field_with_info(
         1,
-        "analog_layout",
+        name,
         FieldDataType::AnalogWatchfaceLayout,
         scale,
         offset,
@@ -9236,9 +9281,14 @@ fn dive_settings_message_heart_rate_antplus_device_type_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "heart_rate_source"
+    } else {
+        "heart_rate_antplus_device_type"
+    };
     data_field_with_info(
         20,
-        "heart_rate_antplus_device_type",
+        name,
         FieldDataType::AntplusDeviceType,
         scale,
         offset,
@@ -9263,9 +9313,14 @@ fn dive_settings_message_heart_rate_local_device_type_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "heart_rate_source"
+    } else {
+        "heart_rate_local_device_type"
+    };
     data_field_with_info(
         20,
-        "heart_rate_local_device_type",
+        name,
         FieldDataType::LocalDeviceType,
         scale,
         offset,
@@ -12921,9 +12976,14 @@ fn session_message_total_strides_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "total_cycles"
+    } else {
+        "total_strides"
+    };
     data_field_with_info(
         10,
-        "total_strides",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -12948,9 +13008,14 @@ fn session_message_total_strokes_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "total_cycles"
+    } else {
+        "total_strokes"
+    };
     data_field_with_info(
         10,
-        "total_strokes",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -13110,9 +13175,14 @@ fn session_message_avg_running_cadence_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "avg_cadence"
+    } else {
+        "avg_running_cadence"
+    };
     data_field_with_info(
         18,
-        "avg_running_cadence",
+        name,
         FieldDataType::UInt8,
         scale,
         offset,
@@ -13164,9 +13234,14 @@ fn session_message_max_running_cadence_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "max_cadence"
+    } else {
+        "max_running_cadence"
+    };
     data_field_with_info(
         19,
-        "max_running_cadence",
+        name,
         FieldDataType::UInt8,
         scale,
         offset,
@@ -18164,9 +18239,14 @@ fn lap_message_total_strides_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "total_cycles"
+    } else {
+        "total_strides"
+    };
     data_field_with_info(
         10,
-        "total_strides",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -18191,9 +18271,14 @@ fn lap_message_total_strokes_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "total_cycles"
+    } else {
+        "total_strokes"
+    };
     data_field_with_info(
         10,
-        "total_strokes",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -18353,9 +18438,14 @@ fn lap_message_avg_running_cadence_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "avg_cadence"
+    } else {
+        "avg_running_cadence"
+    };
     data_field_with_info(
         17,
-        "avg_running_cadence",
+        name,
         FieldDataType::UInt8,
         scale,
         offset,
@@ -18407,9 +18497,14 @@ fn lap_message_max_running_cadence_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "max_cadence"
+    } else {
+        "max_running_cadence"
+    };
     data_field_with_info(
         18,
-        "max_running_cadence",
+        name,
         FieldDataType::UInt8,
         scale,
         offset,
@@ -25746,9 +25841,14 @@ fn event_message_timer_trigger_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "timer_trigger"
+    };
     data_field_with_info(
         3,
-        "timer_trigger",
+        name,
         FieldDataType::TimerTrigger,
         scale,
         offset,
@@ -25773,9 +25873,14 @@ fn event_message_course_point_index_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "course_point_index"
+    };
     data_field_with_info(
         3,
-        "course_point_index",
+        name,
         FieldDataType::MessageIndex,
         scale,
         offset,
@@ -25800,9 +25905,14 @@ fn event_message_battery_level_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "battery_level"
+    };
     data_field_with_info(
         3,
-        "battery_level",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -25827,9 +25937,14 @@ fn event_message_virtual_partner_speed_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "virtual_partner_speed"
+    };
     data_field_with_info(
         3,
-        "virtual_partner_speed",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -25854,9 +25969,14 @@ fn event_message_hr_high_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "hr_high_alert"
+    };
     data_field_with_info(
         3,
-        "hr_high_alert",
+        name,
         FieldDataType::UInt8,
         scale,
         offset,
@@ -25881,9 +26001,14 @@ fn event_message_hr_low_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "hr_low_alert"
+    };
     data_field_with_info(
         3,
-        "hr_low_alert",
+        name,
         FieldDataType::UInt8,
         scale,
         offset,
@@ -25908,9 +26033,14 @@ fn event_message_speed_high_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "speed_high_alert"
+    };
     data_field_with_info(
         3,
-        "speed_high_alert",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -25935,9 +26065,14 @@ fn event_message_speed_low_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "speed_low_alert"
+    };
     data_field_with_info(
         3,
-        "speed_low_alert",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -25962,9 +26097,14 @@ fn event_message_cad_high_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "cad_high_alert"
+    };
     data_field_with_info(
         3,
-        "cad_high_alert",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -25989,9 +26129,14 @@ fn event_message_cad_low_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "cad_low_alert"
+    };
     data_field_with_info(
         3,
-        "cad_low_alert",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -26016,9 +26161,14 @@ fn event_message_power_high_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "power_high_alert"
+    };
     data_field_with_info(
         3,
-        "power_high_alert",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -26043,9 +26193,14 @@ fn event_message_power_low_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "power_low_alert"
+    };
     data_field_with_info(
         3,
-        "power_low_alert",
+        name,
         FieldDataType::UInt16,
         scale,
         offset,
@@ -26070,9 +26225,14 @@ fn event_message_time_duration_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "time_duration_alert"
+    };
     data_field_with_info(
         3,
-        "time_duration_alert",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -26097,9 +26257,14 @@ fn event_message_distance_duration_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "distance_duration_alert"
+    };
     data_field_with_info(
         3,
-        "distance_duration_alert",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -26124,9 +26289,14 @@ fn event_message_calorie_duration_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "calorie_duration_alert"
+    };
     data_field_with_info(
         3,
-        "calorie_duration_alert",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -26151,9 +26321,14 @@ fn event_message_fitness_equipment_state_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "fitness_equipment_state"
+    };
     data_field_with_info(
         3,
-        "fitness_equipment_state",
+        name,
         FieldDataType::FitnessEquipmentState,
         scale,
         offset,
@@ -26178,9 +26353,14 @@ fn event_message_sport_point_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "sport_point"
+    };
     data_field_with_info(
         3,
-        "sport_point",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -26205,9 +26385,14 @@ fn event_message_gear_change_data_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "gear_change_data"
+    };
     data_field_with_info(
         3,
-        "gear_change_data",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -26232,9 +26417,14 @@ fn event_message_rider_position_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "rider_position"
+    };
     data_field_with_info(
         3,
-        "rider_position",
+        name,
         FieldDataType::RiderPositionType,
         scale,
         offset,
@@ -26259,9 +26449,14 @@ fn event_message_comm_timeout_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "comm_timeout"
+    };
     data_field_with_info(
         3,
-        "comm_timeout",
+        name,
         FieldDataType::CommTimeoutType,
         scale,
         offset,
@@ -26286,9 +26481,14 @@ fn event_message_radar_threat_alert_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "data"
+    } else {
+        "radar_threat_alert"
+    };
     data_field_with_info(
         3,
-        "radar_threat_alert",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -27119,9 +27319,14 @@ fn device_info_message_antplus_device_type_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "device_type"
+    } else {
+        "antplus_device_type"
+    };
     data_field_with_info(
         1,
-        "antplus_device_type",
+        name,
         FieldDataType::AntplusDeviceType,
         scale,
         offset,
@@ -27146,9 +27351,14 @@ fn device_info_message_ant_device_type_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "device_type"
+    } else {
+        "ant_device_type"
+    };
     data_field_with_info(
         1,
-        "ant_device_type",
+        name,
         FieldDataType::UInt8,
         scale,
         offset,
@@ -27254,9 +27464,14 @@ fn device_info_message_favero_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "favero_product"
+    };
     data_field_with_info(
         4,
-        "favero_product",
+        name,
         FieldDataType::FaveroProduct,
         scale,
         offset,
@@ -27281,9 +27496,14 @@ fn device_info_message_garmin_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "garmin_product"
+    };
     data_field_with_info(
         4,
-        "garmin_product",
+        name,
         FieldDataType::GarminProduct,
         scale,
         offset,
@@ -28178,9 +28398,14 @@ fn training_file_message_favero_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "favero_product"
+    };
     data_field_with_info(
         2,
-        "favero_product",
+        name,
         FieldDataType::FaveroProduct,
         scale,
         offset,
@@ -28205,9 +28430,14 @@ fn training_file_message_garmin_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "garmin_product"
+    };
     data_field_with_info(
         2,
-        "garmin_product",
+        name,
         FieldDataType::GarminProduct,
         scale,
         offset,
@@ -31542,9 +31772,14 @@ fn three_d_sensor_calibration_message_accel_cal_factor_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "calibration_factor"
+    } else {
+        "accel_cal_factor"
+    };
     data_field_with_info(
         1,
-        "accel_cal_factor",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -31569,9 +31804,14 @@ fn three_d_sensor_calibration_message_gyro_cal_factor_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "calibration_factor"
+    } else {
+        "gyro_cal_factor"
+    };
     data_field_with_info(
         1,
-        "gyro_cal_factor",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -31909,9 +32149,14 @@ fn one_d_sensor_calibration_message_baro_cal_factor_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "calibration_factor"
+    } else {
+        "baro_cal_factor"
+    };
     data_field_with_info(
         1,
-        "baro_cal_factor",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -38966,9 +39211,14 @@ fn segment_lap_message_total_strokes_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "total_cycles"
+    } else {
+        "total_strokes"
+    };
     data_field_with_info(
         10,
-        "total_strokes",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43470,9 +43720,14 @@ fn workout_step_message_duration_time_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "duration_value"
+    } else {
+        "duration_time"
+    };
     data_field_with_info(
         2,
-        "duration_time",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43497,9 +43752,14 @@ fn workout_step_message_duration_distance_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "duration_value"
+    } else {
+        "duration_distance"
+    };
     data_field_with_info(
         2,
-        "duration_distance",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43524,9 +43784,14 @@ fn workout_step_message_duration_hr_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "duration_value"
+    } else {
+        "duration_hr"
+    };
     data_field_with_info(
         2,
-        "duration_hr",
+        name,
         FieldDataType::WorkoutHr,
         scale,
         offset,
@@ -43551,9 +43816,14 @@ fn workout_step_message_duration_calories_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "duration_value"
+    } else {
+        "duration_calories"
+    };
     data_field_with_info(
         2,
-        "duration_calories",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43578,9 +43848,14 @@ fn workout_step_message_duration_step_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "duration_value"
+    } else {
+        "duration_step"
+    };
     data_field_with_info(
         2,
-        "duration_step",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43605,9 +43880,14 @@ fn workout_step_message_duration_power_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "duration_value"
+    } else {
+        "duration_power"
+    };
     data_field_with_info(
         2,
-        "duration_power",
+        name,
         FieldDataType::WorkoutPower,
         scale,
         offset,
@@ -43632,9 +43912,14 @@ fn workout_step_message_duration_reps_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "duration_value"
+    } else {
+        "duration_reps"
+    };
     data_field_with_info(
         2,
-        "duration_reps",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43713,9 +43998,14 @@ fn workout_step_message_target_speed_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "target_speed_zone"
+    };
     data_field_with_info(
         4,
-        "target_speed_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43740,9 +44030,14 @@ fn workout_step_message_target_hr_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "target_hr_zone"
+    };
     data_field_with_info(
         4,
-        "target_hr_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43767,9 +44062,14 @@ fn workout_step_message_target_cadence_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "target_cadence_zone"
+    };
     data_field_with_info(
         4,
-        "target_cadence_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43794,9 +44094,14 @@ fn workout_step_message_target_power_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "target_power_zone"
+    };
     data_field_with_info(
         4,
-        "target_power_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43821,9 +44126,14 @@ fn workout_step_message_repeat_steps_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "repeat_steps"
+    };
     data_field_with_info(
         4,
-        "repeat_steps",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43848,9 +44158,14 @@ fn workout_step_message_repeat_time_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "repeat_time"
+    };
     data_field_with_info(
         4,
-        "repeat_time",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43875,9 +44190,14 @@ fn workout_step_message_repeat_distance_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "repeat_distance"
+    };
     data_field_with_info(
         4,
-        "repeat_distance",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43902,9 +44222,14 @@ fn workout_step_message_repeat_calories_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "repeat_calories"
+    };
     data_field_with_info(
         4,
-        "repeat_calories",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -43929,9 +44254,14 @@ fn workout_step_message_repeat_hr_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "repeat_hr"
+    };
     data_field_with_info(
         4,
-        "repeat_hr",
+        name,
         FieldDataType::WorkoutHr,
         scale,
         offset,
@@ -43956,9 +44286,14 @@ fn workout_step_message_repeat_power_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "repeat_power"
+    };
     data_field_with_info(
         4,
-        "repeat_power",
+        name,
         FieldDataType::WorkoutPower,
         scale,
         offset,
@@ -43983,9 +44318,14 @@ fn workout_step_message_target_stroke_type_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "target_value"
+    } else {
+        "target_stroke_type"
+    };
     data_field_with_info(
         4,
-        "target_stroke_type",
+        name,
         FieldDataType::SwimStroke,
         scale,
         offset,
@@ -44037,9 +44377,14 @@ fn workout_step_message_custom_target_speed_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_low"
+    } else {
+        "custom_target_speed_low"
+    };
     data_field_with_info(
         5,
-        "custom_target_speed_low",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44064,9 +44409,14 @@ fn workout_step_message_custom_target_heart_rate_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_low"
+    } else {
+        "custom_target_heart_rate_low"
+    };
     data_field_with_info(
         5,
-        "custom_target_heart_rate_low",
+        name,
         FieldDataType::WorkoutHr,
         scale,
         offset,
@@ -44091,9 +44441,14 @@ fn workout_step_message_custom_target_cadence_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_low"
+    } else {
+        "custom_target_cadence_low"
+    };
     data_field_with_info(
         5,
-        "custom_target_cadence_low",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44118,9 +44473,14 @@ fn workout_step_message_custom_target_power_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_low"
+    } else {
+        "custom_target_power_low"
+    };
     data_field_with_info(
         5,
-        "custom_target_power_low",
+        name,
         FieldDataType::WorkoutPower,
         scale,
         offset,
@@ -44172,9 +44532,14 @@ fn workout_step_message_custom_target_speed_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_high"
+    } else {
+        "custom_target_speed_high"
+    };
     data_field_with_info(
         6,
-        "custom_target_speed_high",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44199,9 +44564,14 @@ fn workout_step_message_custom_target_heart_rate_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_high"
+    } else {
+        "custom_target_heart_rate_high"
+    };
     data_field_with_info(
         6,
-        "custom_target_heart_rate_high",
+        name,
         FieldDataType::WorkoutHr,
         scale,
         offset,
@@ -44226,9 +44596,14 @@ fn workout_step_message_custom_target_cadence_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_high"
+    } else {
+        "custom_target_cadence_high"
+    };
     data_field_with_info(
         6,
-        "custom_target_cadence_high",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44253,9 +44628,14 @@ fn workout_step_message_custom_target_power_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "custom_target_value_high"
+    } else {
+        "custom_target_power_high"
+    };
     data_field_with_info(
         6,
-        "custom_target_power_high",
+        name,
         FieldDataType::WorkoutPower,
         scale,
         offset,
@@ -44523,9 +44903,14 @@ fn workout_step_message_secondary_target_speed_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_target_value"
+    } else {
+        "secondary_target_speed_zone"
+    };
     data_field_with_info(
         20,
-        "secondary_target_speed_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44550,9 +44935,14 @@ fn workout_step_message_secondary_target_hr_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_target_value"
+    } else {
+        "secondary_target_hr_zone"
+    };
     data_field_with_info(
         20,
-        "secondary_target_hr_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44577,9 +44967,14 @@ fn workout_step_message_secondary_target_cadence_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_target_value"
+    } else {
+        "secondary_target_cadence_zone"
+    };
     data_field_with_info(
         20,
-        "secondary_target_cadence_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44604,9 +44999,14 @@ fn workout_step_message_secondary_target_power_zone_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_target_value"
+    } else {
+        "secondary_target_power_zone"
+    };
     data_field_with_info(
         20,
-        "secondary_target_power_zone",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44631,9 +45031,14 @@ fn workout_step_message_secondary_target_stroke_type_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_target_value"
+    } else {
+        "secondary_target_stroke_type"
+    };
     data_field_with_info(
         20,
-        "secondary_target_stroke_type",
+        name,
         FieldDataType::SwimStroke,
         scale,
         offset,
@@ -44685,9 +45090,14 @@ fn workout_step_message_secondary_custom_target_speed_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_low"
+    } else {
+        "secondary_custom_target_speed_low"
+    };
     data_field_with_info(
         21,
-        "secondary_custom_target_speed_low",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44712,9 +45122,14 @@ fn workout_step_message_secondary_custom_target_heart_rate_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_low"
+    } else {
+        "secondary_custom_target_heart_rate_low"
+    };
     data_field_with_info(
         21,
-        "secondary_custom_target_heart_rate_low",
+        name,
         FieldDataType::WorkoutHr,
         scale,
         offset,
@@ -44739,9 +45154,14 @@ fn workout_step_message_secondary_custom_target_cadence_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_low"
+    } else {
+        "secondary_custom_target_cadence_low"
+    };
     data_field_with_info(
         21,
-        "secondary_custom_target_cadence_low",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44766,9 +45186,14 @@ fn workout_step_message_secondary_custom_target_power_low_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_low"
+    } else {
+        "secondary_custom_target_power_low"
+    };
     data_field_with_info(
         21,
-        "secondary_custom_target_power_low",
+        name,
         FieldDataType::WorkoutPower,
         scale,
         offset,
@@ -44820,9 +45245,14 @@ fn workout_step_message_secondary_custom_target_speed_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_high"
+    } else {
+        "secondary_custom_target_speed_high"
+    };
     data_field_with_info(
         22,
-        "secondary_custom_target_speed_high",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44847,9 +45277,14 @@ fn workout_step_message_secondary_custom_target_heart_rate_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_high"
+    } else {
+        "secondary_custom_target_heart_rate_high"
+    };
     data_field_with_info(
         22,
-        "secondary_custom_target_heart_rate_high",
+        name,
         FieldDataType::WorkoutHr,
         scale,
         offset,
@@ -44874,9 +45309,14 @@ fn workout_step_message_secondary_custom_target_cadence_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_high"
+    } else {
+        "secondary_custom_target_cadence_high"
+    };
     data_field_with_info(
         22,
-        "secondary_custom_target_cadence_high",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -44901,9 +45341,14 @@ fn workout_step_message_secondary_custom_target_power_high_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "secondary_custom_target_value_high"
+    } else {
+        "secondary_custom_target_power_high"
+    };
     data_field_with_info(
         22,
-        "secondary_custom_target_power_high",
+        name,
         FieldDataType::WorkoutPower,
         scale,
         offset,
@@ -45397,9 +45842,14 @@ fn schedule_message_favero_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "favero_product"
+    };
     data_field_with_info(
         1,
-        "favero_product",
+        name,
         FieldDataType::FaveroProduct,
         scale,
         offset,
@@ -45424,9 +45874,14 @@ fn schedule_message_garmin_product_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "product"
+    } else {
+        "garmin_product"
+    };
     data_field_with_info(
         1,
-        "garmin_product",
+        name,
         FieldDataType::GarminProduct,
         scale,
         offset,
@@ -47885,9 +48340,14 @@ fn monitoring_message_steps_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "cycles"
+    } else {
+        "steps"
+    };
     data_field_with_info(
         3,
-        "steps",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,
@@ -47912,9 +48372,14 @@ fn monitoring_message_strokes_field(
     } else {
         value
     };
+    let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {
+        "cycles"
+    } else {
+        "strokes"
+    };
     data_field_with_info(
         3,
-        "strokes",
+        name,
         FieldDataType::UInt32,
         scale,
         offset,

--- a/fitparser/src/profile/field_types.rs
+++ b/fitparser/src/profile/field_types.rs
@@ -51,6 +51,31 @@ pub enum File {
     UnknownVariant(u8),
 }
 impl File {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            14 => true,
+            15 => true,
+            20 => true,
+            28 => true,
+            32 => true,
+            34 => true,
+            35 => true,
+            40 => true,
+            247 => true,
+            254 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             File::Device => 1,
@@ -245,6 +270,102 @@ pub enum MesgNum {
     UnknownVariant(u16),
 }
 impl MesgNum {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            12 => true,
+            15 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            23 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            49 => true,
+            51 => true,
+            53 => true,
+            55 => true,
+            72 => true,
+            78 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            101 => true,
+            103 => true,
+            105 => true,
+            106 => true,
+            127 => true,
+            128 => true,
+            129 => true,
+            131 => true,
+            132 => true,
+            142 => true,
+            145 => true,
+            148 => true,
+            149 => true,
+            150 => true,
+            151 => true,
+            158 => true,
+            159 => true,
+            160 => true,
+            161 => true,
+            162 => true,
+            164 => true,
+            165 => true,
+            167 => true,
+            169 => true,
+            174 => true,
+            177 => true,
+            178 => true,
+            184 => true,
+            185 => true,
+            186 => true,
+            187 => true,
+            188 => true,
+            200 => true,
+            201 => true,
+            202 => true,
+            206 => true,
+            207 => true,
+            208 => true,
+            209 => true,
+            210 => true,
+            225 => true,
+            227 => true,
+            258 => true,
+            259 => true,
+            262 => true,
+            264 => true,
+            268 => true,
+            285 => true,
+            317 => true,
+            375 => true,
+            65280 => true,
+            65534 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             MesgNum::FileId => 0,
@@ -563,6 +684,13 @@ pub enum Checksum {
     UnknownVariant(u8),
 }
 impl Checksum {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Checksum::Clear => 0,
@@ -613,6 +741,14 @@ pub enum FileFlags {
     UnknownVariant(u8),
 }
 impl FileFlags {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            2 => true,
+            4 => true,
+            8 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             FileFlags::Read => 2,
@@ -666,6 +802,14 @@ pub enum MesgCount {
     UnknownVariant(u8),
 }
 impl MesgCount {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             MesgCount::NumPerFile => 0,
@@ -719,6 +863,12 @@ pub enum DateTime {
     UnknownVariant(u32),
 }
 impl DateTime {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            268435456 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             DateTime::Min => 268435456,
@@ -766,6 +916,12 @@ pub enum LocalDateTime {
     UnknownVariant(u32),
 }
 impl LocalDateTime {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            268435456 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             LocalDateTime::Min => 268435456,
@@ -816,6 +972,14 @@ pub enum MessageIndex {
     UnknownVariant(u16),
 }
 impl MessageIndex {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            4095 => true,
+            28672 => true,
+            32768 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             MessageIndex::Mask => 4095,
@@ -868,6 +1032,12 @@ pub enum DeviceIndex {
     UnknownVariant(u8),
 }
 impl DeviceIndex {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DeviceIndex::Creator => 0,
@@ -914,6 +1084,13 @@ pub enum Gender {
     UnknownVariant(u8),
 }
 impl Gender {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Gender::Female => 0,
@@ -1000,6 +1177,50 @@ pub enum Language {
     UnknownVariant(u8),
 }
 impl Language {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            254 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Language::English => 0,
@@ -1167,6 +1388,19 @@ pub enum LanguageBits0 {
     UnknownVariant(u8),
 }
 impl LanguageBits0 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LanguageBits0::English => 1,
@@ -1240,6 +1474,19 @@ pub enum LanguageBits1 {
     UnknownVariant(u8),
 }
 impl LanguageBits1 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LanguageBits1::Dutch => 1,
@@ -1313,6 +1560,19 @@ pub enum LanguageBits2 {
     UnknownVariant(u8),
 }
 impl LanguageBits2 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LanguageBits2::Slovenian => 1,
@@ -1386,6 +1646,19 @@ pub enum LanguageBits3 {
     UnknownVariant(u8),
 }
 impl LanguageBits3 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LanguageBits3::Bulgarian => 1,
@@ -1457,6 +1730,17 @@ pub enum LanguageBits4 {
     UnknownVariant(u8),
 }
 impl LanguageBits4 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LanguageBits4::BrazilianPortuguese => 1,
@@ -1622,6 +1906,117 @@ pub enum TimeZone {
     UnknownVariant(u8),
 }
 impl TimeZone {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            83 => true,
+            84 => true,
+            85 => true,
+            86 => true,
+            87 => true,
+            88 => true,
+            89 => true,
+            90 => true,
+            91 => true,
+            92 => true,
+            93 => true,
+            94 => true,
+            95 => true,
+            96 => true,
+            97 => true,
+            98 => true,
+            99 => true,
+            100 => true,
+            101 => true,
+            102 => true,
+            103 => true,
+            253 => true,
+            254 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             TimeZone::Almaty => 0,
@@ -1984,6 +2379,14 @@ pub enum DisplayMeasure {
     UnknownVariant(u8),
 }
 impl DisplayMeasure {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DisplayMeasure::Metric => 0,
@@ -2037,6 +2440,14 @@ pub enum DisplayHeart {
     UnknownVariant(u8),
 }
 impl DisplayHeart {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DisplayHeart::Bpm => 0,
@@ -2089,6 +2500,13 @@ pub enum DisplayPower {
     UnknownVariant(u8),
 }
 impl DisplayPower {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DisplayPower::Watts => 0,
@@ -2220,6 +2638,53 @@ pub enum DisplayPosition {
     UnknownVariant(u8),
 }
 impl DisplayPosition {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DisplayPosition::Degree => 0,
@@ -2390,6 +2855,14 @@ pub enum Switch {
     UnknownVariant(u8),
 }
 impl Switch {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Switch::Off => 0,
@@ -2493,6 +2966,62 @@ pub enum Sport {
     UnknownVariant(u8),
 }
 impl Sport {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            53 => true,
+            254 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Sport::Generic => 0,
@@ -2697,6 +3226,19 @@ pub enum SportBits0 {
     UnknownVariant(u8),
 }
 impl SportBits0 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits0::Generic => 1,
@@ -2771,6 +3313,19 @@ pub enum SportBits1 {
     UnknownVariant(u8),
 }
 impl SportBits1 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits1::Tennis => 1,
@@ -2845,6 +3400,19 @@ pub enum SportBits2 {
     UnknownVariant(u8),
 }
 impl SportBits2 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits2::Mountaineering => 1,
@@ -2919,6 +3487,19 @@ pub enum SportBits3 {
     UnknownVariant(u8),
 }
 impl SportBits3 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits3::Driving => 1,
@@ -2993,6 +3574,19 @@ pub enum SportBits4 {
     UnknownVariant(u8),
 }
 impl SportBits4 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits4::Sailing => 1,
@@ -3067,6 +3661,19 @@ pub enum SportBits5 {
     UnknownVariant(u8),
 }
 impl SportBits5 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits5::WaterSkiing => 1,
@@ -3134,6 +3741,12 @@ pub enum SportBits6 {
     UnknownVariant(u8),
 }
 impl SportBits6 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits6::FloorClimbing => 1,
@@ -3302,6 +3915,77 @@ pub enum SubSport {
     UnknownVariant(u8),
 }
 impl SubSport {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            62 => true,
+            65 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            254 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SubSport::Generic => 0,
@@ -3550,6 +4234,20 @@ pub enum SportEvent {
     UnknownVariant(u8),
 }
 impl SportEvent {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SportEvent::Uncategorized => 0,
@@ -3620,6 +4318,13 @@ pub enum Activity {
     UnknownVariant(u8),
 }
 impl Activity {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Activity::Manual => 0,
@@ -3674,6 +4379,18 @@ pub enum Intensity {
     UnknownVariant(u8),
 }
 impl Intensity {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Intensity::Active => 0,
@@ -3743,6 +4460,15 @@ pub enum SessionTrigger {
     UnknownVariant(u8),
 }
 impl SessionTrigger {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SessionTrigger::ActivityEnd => 0,
@@ -3803,6 +4529,18 @@ pub enum AutolapTrigger {
     UnknownVariant(u8),
 }
 impl AutolapTrigger {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             AutolapTrigger::Time => 0,
@@ -3874,6 +4612,20 @@ pub enum LapTrigger {
     UnknownVariant(u8),
 }
 impl LapTrigger {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LapTrigger::Manual => 0,
@@ -3950,6 +4702,17 @@ pub enum TimeMode {
     UnknownVariant(u8),
 }
 impl TimeMode {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             TimeMode::Hour12 => 0,
@@ -4016,6 +4779,18 @@ pub enum BacklightMode {
     UnknownVariant(u8),
 }
 impl BacklightMode {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             BacklightMode::Off => 0,
@@ -4082,6 +4857,13 @@ pub enum DateMode {
     UnknownVariant(u8),
 }
 impl DateMode {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DateMode::DayMonth => 0,
@@ -4132,6 +4914,12 @@ pub enum BacklightTimeout {
     UnknownVariant(u8),
 }
 impl BacklightTimeout {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             BacklightTimeout::Infinite => 0,
@@ -4250,6 +5038,48 @@ pub enum Event {
     UnknownVariant(u8),
 }
 impl Event {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            32 => true,
+            33 => true,
+            36 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            75 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Event::Timer => 0,
@@ -4412,6 +5242,21 @@ pub enum EventType {
     UnknownVariant(u8),
 }
 impl EventType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             EventType::Start => 0,
@@ -4487,6 +5332,14 @@ pub enum TimerTrigger {
     UnknownVariant(u8),
 }
 impl TimerTrigger {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             TimerTrigger::Manual => 0,
@@ -4543,6 +5396,15 @@ pub enum FitnessEquipmentState {
     UnknownVariant(u8),
 }
 impl FitnessEquipmentState {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             FitnessEquipmentState::Ready => 0,
@@ -4600,6 +5462,15 @@ pub enum Tone {
     UnknownVariant(u8),
 }
 impl Tone {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Tone::Off => 0,
@@ -4657,6 +5528,15 @@ pub enum Autoscroll {
     UnknownVariant(u8),
 }
 impl Autoscroll {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Autoscroll::None => 0,
@@ -4714,6 +5594,14 @@ pub enum ActivityClass {
     UnknownVariant(u8),
 }
 impl ActivityClass {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            100 => true,
+            127 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ActivityClass::LevelMax => 100,
@@ -4767,6 +5655,14 @@ pub enum HrZoneCalc {
     UnknownVariant(u8),
 }
 impl HrZoneCalc {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             HrZoneCalc::Custom => 0,
@@ -4819,6 +5715,13 @@ pub enum PwrZoneCalc {
     UnknownVariant(u8),
 }
 impl PwrZoneCalc {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             PwrZoneCalc::Custom => 0,
@@ -4897,6 +5800,42 @@ pub enum WktStepDuration {
     UnknownVariant(u8),
 }
 impl WktStepDuration {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            31 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WktStepDuration::Time => 0,
@@ -5053,6 +5992,25 @@ pub enum WktStepTarget {
     UnknownVariant(u8),
 }
 impl WktStepTarget {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WktStepTarget::Speed => 0,
@@ -5143,6 +6101,18 @@ pub enum Goal {
     UnknownVariant(u8),
 }
 impl Goal {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Goal::Time => 0,
@@ -5211,6 +6181,17 @@ pub enum GoalRecurrence {
     UnknownVariant(u8),
 }
 impl GoalRecurrence {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             GoalRecurrence::Off => 0,
@@ -5276,6 +6257,14 @@ pub enum GoalSource {
     UnknownVariant(u8),
 }
 impl GoalSource {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             GoalSource::Auto => 0,
@@ -5328,6 +6317,13 @@ pub enum Schedule {
     UnknownVariant(u8),
 }
 impl Schedule {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Schedule::Workout => 0,
@@ -5429,6 +6425,64 @@ pub enum CoursePoint {
     UnknownVariant(u8),
 }
 impl CoursePoint {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             CoursePoint::Generic => 0,
@@ -5845,6 +6899,218 @@ pub enum Manufacturer {
     UnknownVariant(u16),
 }
 impl Manufacturer {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            83 => true,
+            84 => true,
+            85 => true,
+            86 => true,
+            87 => true,
+            88 => true,
+            89 => true,
+            90 => true,
+            91 => true,
+            92 => true,
+            93 => true,
+            94 => true,
+            95 => true,
+            96 => true,
+            97 => true,
+            98 => true,
+            99 => true,
+            100 => true,
+            101 => true,
+            102 => true,
+            103 => true,
+            104 => true,
+            105 => true,
+            106 => true,
+            107 => true,
+            108 => true,
+            109 => true,
+            110 => true,
+            111 => true,
+            112 => true,
+            113 => true,
+            114 => true,
+            115 => true,
+            116 => true,
+            117 => true,
+            118 => true,
+            119 => true,
+            120 => true,
+            121 => true,
+            122 => true,
+            123 => true,
+            124 => true,
+            125 => true,
+            126 => true,
+            127 => true,
+            128 => true,
+            129 => true,
+            130 => true,
+            131 => true,
+            132 => true,
+            133 => true,
+            134 => true,
+            135 => true,
+            136 => true,
+            137 => true,
+            138 => true,
+            139 => true,
+            140 => true,
+            141 => true,
+            142 => true,
+            143 => true,
+            144 => true,
+            255 => true,
+            257 => true,
+            258 => true,
+            259 => true,
+            260 => true,
+            261 => true,
+            262 => true,
+            263 => true,
+            264 => true,
+            265 => true,
+            266 => true,
+            267 => true,
+            268 => true,
+            269 => true,
+            270 => true,
+            271 => true,
+            272 => true,
+            273 => true,
+            274 => true,
+            275 => true,
+            276 => true,
+            277 => true,
+            278 => true,
+            279 => true,
+            280 => true,
+            281 => true,
+            282 => true,
+            283 => true,
+            284 => true,
+            285 => true,
+            286 => true,
+            287 => true,
+            288 => true,
+            289 => true,
+            290 => true,
+            291 => true,
+            292 => true,
+            293 => true,
+            294 => true,
+            295 => true,
+            296 => true,
+            297 => true,
+            298 => true,
+            299 => true,
+            300 => true,
+            301 => true,
+            302 => true,
+            303 => true,
+            304 => true,
+            305 => true,
+            306 => true,
+            307 => true,
+            308 => true,
+            309 => true,
+            310 => true,
+            311 => true,
+            312 => true,
+            313 => true,
+            314 => true,
+            315 => true,
+            316 => true,
+            317 => true,
+            318 => true,
+            319 => true,
+            5759 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             Manufacturer::Garmin => 1,
@@ -6938,6 +8204,403 @@ pub enum GarminProduct {
     UnknownVariant(u16),
 }
 impl GarminProduct {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            255 => true,
+            473 => true,
+            474 => true,
+            475 => true,
+            494 => true,
+            717 => true,
+            782 => true,
+            987 => true,
+            988 => true,
+            1011 => true,
+            1018 => true,
+            1036 => true,
+            1124 => true,
+            1169 => true,
+            1199 => true,
+            1213 => true,
+            1253 => true,
+            1274 => true,
+            1325 => true,
+            1328 => true,
+            1333 => true,
+            1334 => true,
+            1341 => true,
+            1345 => true,
+            1360 => true,
+            1380 => true,
+            1381 => true,
+            1386 => true,
+            1387 => true,
+            1405 => true,
+            1410 => true,
+            1422 => true,
+            1436 => true,
+            1446 => true,
+            1461 => true,
+            1482 => true,
+            1497 => true,
+            1499 => true,
+            1537 => true,
+            1551 => true,
+            1555 => true,
+            1561 => true,
+            1567 => true,
+            1570 => true,
+            1600 => true,
+            1623 => true,
+            1632 => true,
+            1664 => true,
+            1688 => true,
+            1721 => true,
+            1735 => true,
+            1736 => true,
+            1742 => true,
+            1743 => true,
+            1752 => true,
+            1765 => true,
+            1821 => true,
+            1822 => true,
+            1823 => true,
+            1836 => true,
+            1837 => true,
+            1853 => true,
+            1885 => true,
+            1903 => true,
+            1907 => true,
+            1918 => true,
+            1928 => true,
+            1929 => true,
+            1930 => true,
+            1931 => true,
+            1936 => true,
+            1956 => true,
+            1967 => true,
+            1988 => true,
+            2050 => true,
+            2052 => true,
+            2053 => true,
+            2061 => true,
+            2067 => true,
+            2070 => true,
+            2072 => true,
+            2073 => true,
+            2079 => true,
+            2100 => true,
+            2130 => true,
+            2131 => true,
+            2132 => true,
+            2134 => true,
+            2135 => true,
+            2140 => true,
+            2147 => true,
+            2148 => true,
+            2150 => true,
+            2153 => true,
+            2156 => true,
+            2157 => true,
+            2158 => true,
+            2160 => true,
+            2161 => true,
+            2162 => true,
+            2172 => true,
+            2173 => true,
+            2174 => true,
+            2175 => true,
+            2187 => true,
+            2188 => true,
+            2189 => true,
+            2192 => true,
+            2193 => true,
+            2204 => true,
+            2219 => true,
+            2225 => true,
+            2226 => true,
+            2238 => true,
+            2260 => true,
+            2261 => true,
+            2262 => true,
+            2266 => true,
+            2271 => true,
+            2274 => true,
+            2276 => true,
+            2288 => true,
+            2289 => true,
+            2290 => true,
+            2292 => true,
+            2293 => true,
+            2294 => true,
+            2310 => true,
+            2311 => true,
+            2313 => true,
+            2327 => true,
+            2332 => true,
+            2337 => true,
+            2343 => true,
+            2347 => true,
+            2348 => true,
+            2361 => true,
+            2362 => true,
+            2368 => true,
+            2379 => true,
+            2396 => true,
+            2397 => true,
+            2398 => true,
+            2406 => true,
+            2407 => true,
+            2408 => true,
+            2413 => true,
+            2417 => true,
+            2429 => true,
+            2431 => true,
+            2432 => true,
+            2441 => true,
+            2444 => true,
+            2457 => true,
+            2473 => true,
+            2474 => true,
+            2475 => true,
+            2476 => true,
+            2477 => true,
+            2496 => true,
+            2497 => true,
+            2512 => true,
+            2530 => true,
+            2531 => true,
+            2533 => true,
+            2534 => true,
+            2544 => true,
+            2547 => true,
+            2567 => true,
+            2593 => true,
+            2599 => true,
+            2600 => true,
+            2604 => true,
+            2606 => true,
+            2622 => true,
+            2623 => true,
+            2628 => true,
+            2629 => true,
+            2630 => true,
+            2650 => true,
+            2656 => true,
+            2667 => true,
+            2668 => true,
+            2675 => true,
+            2687 => true,
+            2691 => true,
+            2697 => true,
+            2700 => true,
+            2713 => true,
+            2733 => true,
+            2769 => true,
+            2772 => true,
+            2787 => true,
+            2796 => true,
+            2797 => true,
+            2798 => true,
+            2806 => true,
+            2814 => true,
+            2819 => true,
+            2831 => true,
+            2832 => true,
+            2833 => true,
+            2859 => true,
+            2878 => true,
+            2886 => true,
+            2888 => true,
+            2891 => true,
+            2900 => true,
+            2909 => true,
+            2924 => true,
+            2927 => true,
+            2945 => true,
+            2962 => true,
+            2977 => true,
+            2988 => true,
+            3003 => true,
+            3004 => true,
+            3011 => true,
+            3028 => true,
+            3049 => true,
+            3066 => true,
+            3085 => true,
+            3092 => true,
+            3095 => true,
+            3110 => true,
+            3111 => true,
+            3112 => true,
+            3113 => true,
+            3121 => true,
+            3122 => true,
+            3126 => true,
+            3134 => true,
+            3135 => true,
+            3142 => true,
+            3144 => true,
+            3145 => true,
+            3163 => true,
+            3192 => true,
+            3193 => true,
+            3218 => true,
+            3224 => true,
+            3225 => true,
+            3226 => true,
+            3246 => true,
+            3247 => true,
+            3248 => true,
+            3249 => true,
+            3250 => true,
+            3251 => true,
+            3258 => true,
+            3284 => true,
+            3287 => true,
+            3288 => true,
+            3289 => true,
+            3290 => true,
+            3291 => true,
+            3299 => true,
+            3300 => true,
+            3308 => true,
+            3314 => true,
+            3321 => true,
+            3349 => true,
+            3350 => true,
+            3378 => true,
+            3387 => true,
+            3388 => true,
+            3389 => true,
+            3405 => true,
+            3420 => true,
+            3421 => true,
+            3422 => true,
+            3441 => true,
+            3446 => true,
+            3448 => true,
+            3449 => true,
+            3450 => true,
+            3451 => true,
+            3466 => true,
+            3469 => true,
+            3473 => true,
+            3498 => true,
+            3499 => true,
+            3500 => true,
+            3501 => true,
+            3512 => true,
+            3513 => true,
+            3514 => true,
+            3515 => true,
+            3516 => true,
+            3535 => true,
+            3536 => true,
+            3537 => true,
+            3538 => true,
+            3542 => true,
+            3558 => true,
+            3570 => true,
+            3578 => true,
+            3589 => true,
+            3600 => true,
+            3615 => true,
+            3624 => true,
+            3638 => true,
+            3639 => true,
+            3648 => true,
+            3652 => true,
+            3702 => true,
+            3703 => true,
+            3704 => true,
+            3737 => true,
+            3739 => true,
+            3740 => true,
+            3794 => true,
+            3809 => true,
+            3812 => true,
+            3813 => true,
+            3823 => true,
+            3837 => true,
+            3850 => true,
+            3851 => true,
+            3869 => true,
+            3872 => true,
+            3888 => true,
+            3905 => true,
+            3906 => true,
+            3907 => true,
+            3908 => true,
+            3909 => true,
+            3910 => true,
+            3930 => true,
+            3934 => true,
+            3943 => true,
+            3944 => true,
+            3949 => true,
+            3950 => true,
+            3978 => true,
+            3986 => true,
+            3990 => true,
+            3991 => true,
+            3992 => true,
+            3993 => true,
+            4002 => true,
+            4005 => true,
+            4017 => true,
+            4024 => true,
+            4033 => true,
+            4063 => true,
+            4071 => true,
+            4125 => true,
+            4130 => true,
+            4132 => true,
+            4135 => true,
+            4169 => true,
+            4265 => true,
+            4266 => true,
+            4267 => true,
+            4268 => true,
+            4269 => true,
+            4270 => true,
+            4271 => true,
+            4272 => true,
+            4273 => true,
+            4274 => true,
+            4275 => true,
+            4276 => true,
+            10007 => true,
+            10014 => true,
+            20119 => true,
+            20533 => true,
+            20534 => true,
+            20565 => true,
+            30045 => true,
+            30046 => true,
+            30047 => true,
+            65531 => true,
+            65532 => true,
+            65534 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             GarminProduct::ApproachG12Asia => 1,
@@ -8188,6 +9851,36 @@ pub enum AntplusDeviceType {
     UnknownVariant(u8),
 }
 impl AntplusDeviceType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            11 => true,
+            12 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            31 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            38 => true,
+            40 => true,
+            46 => true,
+            119 => true,
+            120 => true,
+            121 => true,
+            122 => true,
+            123 => true,
+            124 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             AntplusDeviceType::Antfs => 1,
@@ -8308,6 +10001,15 @@ pub enum AntNetwork {
     UnknownVariant(u8),
 }
 impl AntNetwork {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             AntNetwork::Public => 0,
@@ -8383,6 +10085,25 @@ pub enum WorkoutCapabilities {
     UnknownVariant(u32),
 }
 impl WorkoutCapabilities {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            128 => true,
+            256 => true,
+            512 => true,
+            1024 => true,
+            2048 => true,
+            4096 => true,
+            8192 => true,
+            16384 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             WorkoutCapabilities::Interval => 1,
@@ -8473,6 +10194,18 @@ pub enum BatteryStatus {
     UnknownVariant(u8),
 }
 impl BatteryStatus {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             BatteryStatus::New => 1,
@@ -8537,6 +10270,13 @@ pub enum HrType {
     UnknownVariant(u8),
 }
 impl HrType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             HrType::Normal => 0,
@@ -8595,6 +10335,22 @@ pub enum CourseCapabilities {
     UnknownVariant(u32),
 }
 impl CourseCapabilities {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            256 => true,
+            512 => true,
+            1024 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             CourseCapabilities::Processed => 1,
@@ -8670,6 +10426,12 @@ pub enum Weight {
     UnknownVariant(u16),
 }
 impl Weight {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            65534 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             Weight::Calculating => 65534,
@@ -8716,6 +10478,12 @@ pub enum WorkoutHr {
     UnknownVariant(u32),
 }
 impl WorkoutHr {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            100 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             WorkoutHr::BpmOffset => 100,
@@ -8762,6 +10530,12 @@ pub enum WorkoutPower {
     UnknownVariant(u32),
 }
 impl WorkoutPower {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1000 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             WorkoutPower::WattsOffset => 1000,
@@ -8811,6 +10585,16 @@ pub enum BpStatus {
     UnknownVariant(u8),
 }
 impl BpStatus {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             BpStatus::NoError => 0,
@@ -8873,6 +10657,17 @@ pub enum UserLocalId {
     UnknownVariant(u16),
 }
 impl UserLocalId {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            15 => true,
+            16 => true,
+            255 => true,
+            256 => true,
+            65534 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             UserLocalId::LocalMin => 0,
@@ -8940,6 +10735,18 @@ pub enum SwimStroke {
     UnknownVariant(u8),
 }
 impl SwimStroke {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SwimStroke::Freestyle => 0,
@@ -9013,6 +10820,20 @@ pub enum ActivityType {
     UnknownVariant(u8),
 }
 impl ActivityType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            8 => true,
+            254 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ActivityType::Generic => 0,
@@ -9119,6 +10940,31 @@ pub enum ActivitySubtype {
     UnknownVariant(u8),
 }
 impl ActivitySubtype {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            254 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ActivitySubtype::Generic => 0,
@@ -9223,6 +11069,14 @@ pub enum ActivityLevel {
     UnknownVariant(u8),
 }
 impl ActivityLevel {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ActivityLevel::Low => 0,
@@ -9275,6 +11129,13 @@ pub enum Side {
     UnknownVariant(u8),
 }
 impl Side {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             Side::Right => 0,
@@ -9326,6 +11187,13 @@ pub enum LeftRightBalance {
     UnknownVariant(u8),
 }
 impl LeftRightBalance {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            127 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LeftRightBalance::Mask => 127,
@@ -9377,6 +11245,13 @@ pub enum LeftRightBalance100 {
     UnknownVariant(u16),
 }
 impl LeftRightBalance100 {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            16383 => true,
+            32768 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             LeftRightBalance100::Mask => 16383,
@@ -9428,6 +11303,13 @@ pub enum LengthType {
     UnknownVariant(u8),
 }
 impl LengthType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             LengthType::Idle => 0,
@@ -9482,6 +11364,18 @@ pub enum DayOfWeek {
     UnknownVariant(u8),
 }
 impl DayOfWeek {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DayOfWeek::Sunday => 0,
@@ -9585,6 +11479,43 @@ pub enum ConnectivityCapabilities {
     UnknownVariant(u32),
 }
 impl ConnectivityCapabilities {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            256 => true,
+            512 => true,
+            1024 => true,
+            2048 => true,
+            4096 => true,
+            8192 => true,
+            16384 => true,
+            32768 => true,
+            65536 => true,
+            131072 => true,
+            262144 => true,
+            524288 => true,
+            1048576 => true,
+            2097152 => true,
+            4194304 => true,
+            8388608 => true,
+            16777216 => true,
+            33554432 => true,
+            67108864 => true,
+            134217728 => true,
+            268435456 => true,
+            536870912 => true,
+            1073741824 => true,
+            2147483648 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             ConnectivityCapabilities::Bluetooth => 1,
@@ -9739,6 +11670,14 @@ pub enum WeatherReport {
     UnknownVariant(u8),
 }
 impl WeatherReport {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WeatherReport::Current => 0,
@@ -9810,6 +11749,32 @@ pub enum WeatherStatus {
     UnknownVariant(u8),
 }
 impl WeatherStatus {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WeatherStatus::Clear => 0,
@@ -9919,6 +11884,16 @@ pub enum WeatherSeverity {
     UnknownVariant(u8),
 }
 impl WeatherSeverity {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WeatherSeverity::Unknown => 0,
@@ -10060,6 +12035,96 @@ pub enum WeatherSevereType {
     UnknownVariant(u8),
 }
 impl WeatherSevereType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            83 => true,
+            84 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WeatherSevereType::Unspecified => 0,
@@ -10363,6 +12428,17 @@ pub enum StrokeType {
     UnknownVariant(u8),
 }
 impl StrokeType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             StrokeType::NoEvent => 0,
@@ -10466,6 +12542,51 @@ pub enum BodyLocation {
     UnknownVariant(u8),
 }
 impl BodyLocation {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             BodyLocation::LeftLeg => 0,
@@ -10629,6 +12750,13 @@ pub enum SegmentLapStatus {
     UnknownVariant(u8),
 }
 impl SegmentLapStatus {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SegmentLapStatus::End => 0,
@@ -10687,6 +12815,22 @@ pub enum SegmentLeaderboardType {
     UnknownVariant(u8),
 }
 impl SegmentLeaderboardType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SegmentLeaderboardType::Overall => 0,
@@ -10766,6 +12910,14 @@ pub enum SegmentDeleteStatus {
     UnknownVariant(u8),
 }
 impl SegmentDeleteStatus {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SegmentDeleteStatus::DoNotDelete => 0,
@@ -10818,6 +12970,13 @@ pub enum SegmentSelectionType {
     UnknownVariant(u8),
 }
 impl SegmentSelectionType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SegmentSelectionType::Starred => 0,
@@ -10877,6 +13036,17 @@ pub enum SourceType {
     UnknownVariant(u8),
 }
 impl SourceType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SourceType::Ant => 0,
@@ -10944,6 +13114,16 @@ pub enum DisplayOrientation {
     UnknownVariant(u8),
 }
 impl DisplayOrientation {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DisplayOrientation::Auto => 0,
@@ -11006,6 +13186,17 @@ pub enum WorkoutEquipment {
     UnknownVariant(u8),
 }
 impl WorkoutEquipment {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WorkoutEquipment::None => 0,
@@ -11069,6 +13260,15 @@ pub enum WatchfaceMode {
     UnknownVariant(u8),
 }
 impl WatchfaceMode {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WatchfaceMode::Digital => 0,
@@ -11125,6 +13325,14 @@ pub enum DigitalWatchfaceLayout {
     UnknownVariant(u8),
 }
 impl DigitalWatchfaceLayout {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DigitalWatchfaceLayout::Traditional => 0,
@@ -11180,6 +13388,14 @@ pub enum AnalogWatchfaceLayout {
     UnknownVariant(u8),
 }
 impl AnalogWatchfaceLayout {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             AnalogWatchfaceLayout::Minimal => 0,
@@ -11234,6 +13450,15 @@ pub enum RiderPositionType {
     UnknownVariant(u8),
 }
 impl RiderPositionType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             RiderPositionType::Seated => 0,
@@ -11291,6 +13516,15 @@ pub enum PowerPhaseType {
     UnknownVariant(u8),
 }
 impl PowerPhaseType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             PowerPhaseType::PowerPhaseStartAngle => 0,
@@ -11364,6 +13598,24 @@ pub enum CameraEventType {
     UnknownVariant(u8),
 }
 impl CameraEventType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             CameraEventType::VideoStart => 0,
@@ -11451,6 +13703,15 @@ pub enum SensorType {
     UnknownVariant(u8),
 }
 impl SensorType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SensorType::Accelerometer => 0,
@@ -11508,6 +13769,15 @@ pub enum BikeLightNetworkConfigType {
     UnknownVariant(u8),
 }
 impl BikeLightNetworkConfigType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             BikeLightNetworkConfigType::Auto => 0,
@@ -11571,6 +13841,15 @@ pub enum CommTimeoutType {
     UnknownVariant(u16),
 }
 impl CommTimeoutType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             CommTimeoutType::WildcardPairingTimeout => 0,
@@ -11628,6 +13907,15 @@ pub enum CameraOrientationType {
     UnknownVariant(u8),
 }
 impl CameraOrientationType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             CameraOrientationType::CameraOrientation0 => 0,
@@ -11685,6 +13973,15 @@ pub enum AttitudeStage {
     UnknownVariant(u8),
 }
 impl AttitudeStage {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             AttitudeStage::Failed => 0,
@@ -11751,6 +14048,24 @@ pub enum AttitudeValidity {
     UnknownVariant(u16),
 }
 impl AttitudeValidity {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            256 => true,
+            512 => true,
+            1024 => true,
+            2048 => true,
+            4096 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             AttitudeValidity::TrackAngleHeadingValid => 1,
@@ -11836,6 +14151,16 @@ pub enum AutoSyncFrequency {
     UnknownVariant(u8),
 }
 impl AutoSyncFrequency {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             AutoSyncFrequency::Never => 0,
@@ -11902,6 +14227,20 @@ pub enum ExdLayout {
     UnknownVariant(u8),
 }
 impl ExdLayout {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ExdLayout::FullScreen => 0,
@@ -11981,6 +14320,22 @@ pub enum ExdDisplayType {
     UnknownVariant(u8),
 }
 impl ExdDisplayType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ExdDisplayType::Numerical => 0,
@@ -12105,6 +14460,61 @@ pub enum ExdDataUnits {
     UnknownVariant(u8),
 }
 impl ExdDataUnits {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ExdDataUnits::NoUnits => 0,
@@ -12344,6 +14754,55 @@ pub enum ExdQualifiers {
     UnknownVariant(u8),
 }
 impl ExdQualifiers {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            242 => true,
+            243 => true,
+            244 => true,
+            245 => true,
+            246 => true,
+            247 => true,
+            248 => true,
+            249 => true,
+            250 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ExdQualifiers::NoQualifier => 0,
@@ -12615,6 +15074,108 @@ pub enum ExdDescriptors {
     UnknownVariant(u8),
 }
 impl ExdDescriptors {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            83 => true,
+            84 => true,
+            85 => true,
+            86 => true,
+            87 => true,
+            88 => true,
+            89 => true,
+            90 => true,
+            91 => true,
+            92 => true,
+            93 => true,
+            94 => true,
+            95 => true,
+            96 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ExdDescriptors::BikeLightBatteryStatus => 0,
@@ -12964,6 +15525,18 @@ pub enum AutoActivityDetect {
     UnknownVariant(u32),
 }
 impl AutoActivityDetect {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            32 => true,
+            1024 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             AutoActivityDetect::None => 0,
@@ -13034,6 +15607,19 @@ pub enum SupportedExdScreenLayouts {
     UnknownVariant(u32),
 }
 impl SupportedExdScreenLayouts {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            1 => true,
+            2 => true,
+            4 => true,
+            8 => true,
+            16 => true,
+            32 => true,
+            64 => true,
+            128 => true,
+            _ => false,
+        }
+    }
     pub fn as_u32(self) -> u32 {
         match self {
             SupportedExdScreenLayouts::FullScreen => 1,
@@ -13126,6 +15712,28 @@ pub enum FitBaseType {
     UnknownVariant(u8),
 }
 impl FitBaseType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            7 => true,
+            10 => true,
+            13 => true,
+            131 => true,
+            132 => true,
+            133 => true,
+            134 => true,
+            136 => true,
+            137 => true,
+            139 => true,
+            140 => true,
+            142 => true,
+            143 => true,
+            144 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             FitBaseType::Enum => 0,
@@ -13256,6 +15864,49 @@ pub enum TurnType {
     UnknownVariant(u8),
 }
 impl TurnType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             TurnType::ArrivingIdx => 0,
@@ -13413,6 +16064,13 @@ pub enum BikeLightBeamAngleMode {
     UnknownVariant(u8),
 }
 impl BikeLightBeamAngleMode {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             BikeLightBeamAngleMode::Manual => 0,
@@ -13465,6 +16123,14 @@ pub enum FitBaseUnit {
     UnknownVariant(u16),
 }
 impl FitBaseUnit {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             FitBaseUnit::Other => 0,
@@ -13517,6 +16183,13 @@ pub enum SetType {
     UnknownVariant(u8),
 }
 impl SetType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             SetType::Rest => 0,
@@ -13598,6 +16271,45 @@ pub enum ExerciseCategory {
     UnknownVariant(u16),
 }
 impl ExerciseCategory {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            65534 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             ExerciseCategory::BenchPress => 0,
@@ -13768,6 +16480,38 @@ pub enum BenchPressExerciseName {
     UnknownVariant(u16),
 }
 impl BenchPressExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             BenchPressExerciseName::AlternatingDumbbellChestPressOnSwissBall => 0,
@@ -13953,6 +16697,32 @@ pub enum CalfRaiseExerciseName {
     UnknownVariant(u16),
 }
 impl CalfRaiseExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             CalfRaiseExerciseName::Name3WayCalfRaise => 0,
@@ -14111,6 +16881,33 @@ pub enum CardioExerciseName {
     UnknownVariant(u16),
 }
 impl CardioExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             CardioExerciseName::BobAndWeaveCircle => 0,
@@ -14227,6 +17024,16 @@ pub enum CarryExerciseName {
     UnknownVariant(u16),
 }
 impl CarryExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             CarryExerciseName::BarHolds => 0,
@@ -14306,6 +17113,34 @@ pub enum ChopExerciseName {
     UnknownVariant(u16),
 }
 impl ChopExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             ChopExerciseName::CablePullThrough => 0,
@@ -14510,6 +17345,84 @@ pub enum CoreExerciseName {
     UnknownVariant(u16),
 }
 impl CoreExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             CoreExerciseName::AbsJabs => 0,
@@ -14873,6 +17786,96 @@ pub enum CrunchExerciseName {
     UnknownVariant(u16),
 }
 impl CrunchExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            83 => true,
+            84 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             CrunchExerciseName::BicycleCrunch => 0,
@@ -15273,6 +18276,55 @@ pub enum CurlExerciseName {
     UnknownVariant(u16),
 }
 impl CurlExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             CurlExerciseName::AlternatingDumbbellBicepsCurl => 0,
@@ -15507,6 +18559,30 @@ pub enum DeadliftExerciseName {
     UnknownVariant(u16),
 }
 impl DeadliftExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             DeadliftExerciseName::BarbellDeadlift => 0,
@@ -15633,6 +18709,21 @@ pub enum FlyeExerciseName {
     UnknownVariant(u16),
 }
 impl FlyeExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             FlyeExerciseName::CableCrossover => 0,
@@ -15758,6 +18849,61 @@ pub enum HipRaiseExerciseName {
     UnknownVariant(u16),
 }
 impl HipRaiseExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             HipRaiseExerciseName::BarbellHipThrustOnFloor => 0,
@@ -16052,6 +19198,45 @@ pub enum HipStabilityExerciseName {
     UnknownVariant(u16),
 }
 impl HipStabilityExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             HipStabilityExerciseName::BandSideLyingLegRaise => 0,
@@ -16236,6 +19421,14 @@ pub enum HipSwingExerciseName {
     UnknownVariant(u16),
 }
 impl HipSwingExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             HipSwingExerciseName::SingleArmKettlebellSwing => 0,
@@ -16329,6 +19522,51 @@ pub enum HyperextensionExerciseName {
     UnknownVariant(u16),
 }
 impl HyperextensionExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             HyperextensionExerciseName::BackExtensionWithOppositeArmAndLegReach => 0,
@@ -16568,6 +19806,45 @@ pub enum LateralRaiseExerciseName {
     UnknownVariant(u16),
 }
 impl LateralRaiseExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             LateralRaiseExerciseName::Name45DegreeCableExternalRotation => 0,
@@ -16741,6 +20018,23 @@ pub enum LegCurlExerciseName {
     UnknownVariant(u16),
 }
 impl LegCurlExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             LegCurlExerciseName::LegCurl => 0,
@@ -16850,6 +20144,33 @@ pub enum LegRaiseExerciseName {
     UnknownVariant(u16),
 }
 impl LegRaiseExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             LegRaiseExerciseName::HangingKneeRaise => 0,
@@ -17058,6 +20379,92 @@ pub enum LungeExerciseName {
     UnknownVariant(u16),
 }
 impl LungeExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             LungeExerciseName::OverheadLunge => 0,
@@ -17423,6 +20830,32 @@ pub enum OlympicLiftExerciseName {
     UnknownVariant(u16),
 }
 impl OlympicLiftExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             OlympicLiftExerciseName::BarbellHangPowerClean => 0,
@@ -17672,6 +21105,146 @@ pub enum PlankExerciseName {
     UnknownVariant(u16),
 }
 impl PlankExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            83 => true,
+            84 => true,
+            85 => true,
+            86 => true,
+            87 => true,
+            88 => true,
+            89 => true,
+            90 => true,
+            91 => true,
+            92 => true,
+            93 => true,
+            94 => true,
+            95 => true,
+            96 => true,
+            97 => true,
+            98 => true,
+            99 => true,
+            100 => true,
+            101 => true,
+            102 => true,
+            103 => true,
+            104 => true,
+            105 => true,
+            106 => true,
+            107 => true,
+            108 => true,
+            109 => true,
+            110 => true,
+            111 => true,
+            112 => true,
+            113 => true,
+            114 => true,
+            115 => true,
+            116 => true,
+            117 => true,
+            118 => true,
+            119 => true,
+            120 => true,
+            121 => true,
+            122 => true,
+            123 => true,
+            124 => true,
+            125 => true,
+            126 => true,
+            127 => true,
+            128 => true,
+            129 => true,
+            130 => true,
+            131 => true,
+            132 => true,
+            133 => true,
+            134 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             PlankExerciseName::Name45DegreePlank => 0,
@@ -18276,6 +21849,44 @@ pub enum PlyoExerciseName {
     UnknownVariant(u16),
 }
 impl PlyoExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             PlyoExerciseName::AlternatingJumpLunge => 0,
@@ -18473,6 +22084,50 @@ pub enum PullUpExerciseName {
     UnknownVariant(u16),
 }
 impl PullUpExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             PullUpExerciseName::BandedPullUps => 0,
@@ -18712,6 +22367,90 @@ pub enum PushUpExerciseName {
     UnknownVariant(u16),
 }
 impl PushUpExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             PushUpExerciseName::ChestPressWithBand => 0,
@@ -19080,6 +22819,45 @@ pub enum RowExerciseName {
     UnknownVariant(u16),
 }
 impl RowExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             RowExerciseName::BarbellStraightLegDeadliftToRow => 0,
@@ -19273,6 +23051,35 @@ pub enum ShoulderPressExerciseName {
     UnknownVariant(u16),
 }
 impl ShoulderPressExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             ShoulderPressExerciseName::AlternatingDumbbellShoulderPress => 0,
@@ -19455,6 +23262,44 @@ pub enum ShoulderStabilityExerciseName {
     UnknownVariant(u16),
 }
 impl ShoulderStabilityExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             ShoulderStabilityExerciseName::Name90DegreeCableExternalRotation => 0,
@@ -19654,6 +23499,28 @@ pub enum ShrugExerciseName {
     UnknownVariant(u16),
 }
 impl ShrugExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             ShrugExerciseName::BarbellJumpShrug => 0,
@@ -19788,6 +23655,49 @@ pub enum SitUpExerciseName {
     UnknownVariant(u16),
 }
 impl SitUpExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             SitUpExerciseName::AlternatingSitUp => 0,
@@ -20050,6 +23960,103 @@ pub enum SquatExerciseName {
     UnknownVariant(u16),
 }
 impl SquatExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            41 => true,
+            42 => true,
+            43 => true,
+            44 => true,
+            45 => true,
+            46 => true,
+            47 => true,
+            48 => true,
+            49 => true,
+            50 => true,
+            51 => true,
+            52 => true,
+            53 => true,
+            54 => true,
+            55 => true,
+            56 => true,
+            57 => true,
+            58 => true,
+            59 => true,
+            60 => true,
+            61 => true,
+            62 => true,
+            63 => true,
+            64 => true,
+            65 => true,
+            66 => true,
+            67 => true,
+            68 => true,
+            69 => true,
+            70 => true,
+            71 => true,
+            72 => true,
+            73 => true,
+            74 => true,
+            75 => true,
+            76 => true,
+            77 => true,
+            78 => true,
+            79 => true,
+            80 => true,
+            81 => true,
+            82 => true,
+            83 => true,
+            84 => true,
+            85 => true,
+            86 => true,
+            87 => true,
+            88 => true,
+            89 => true,
+            90 => true,
+            91 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             SquatExerciseName::LegPress => 0,
@@ -20417,6 +24424,24 @@ pub enum TotalBodyExerciseName {
     UnknownVariant(u16),
 }
 impl TotalBodyExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             TotalBodyExerciseName::Burpee => 0,
@@ -20544,6 +24569,52 @@ pub enum TricepsExtensionExerciseName {
     UnknownVariant(u16),
 }
 impl TricepsExtensionExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            31 => true,
+            32 => true,
+            33 => true,
+            34 => true,
+            35 => true,
+            36 => true,
+            37 => true,
+            38 => true,
+            39 => true,
+            40 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             TricepsExtensionExerciseName::BenchDip => 0,
@@ -20796,6 +24867,42 @@ pub enum WarmUpExerciseName {
     UnknownVariant(u16),
 }
 impl WarmUpExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+            5 => true,
+            6 => true,
+            7 => true,
+            8 => true,
+            9 => true,
+            10 => true,
+            11 => true,
+            12 => true,
+            13 => true,
+            14 => true,
+            15 => true,
+            16 => true,
+            17 => true,
+            18 => true,
+            19 => true,
+            20 => true,
+            21 => true,
+            22 => true,
+            23 => true,
+            24 => true,
+            25 => true,
+            26 => true,
+            27 => true,
+            28 => true,
+            29 => true,
+            30 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             WarmUpExerciseName::QuadrupedRocking => 0,
@@ -20946,6 +25053,15 @@ pub enum RunExerciseName {
     UnknownVariant(u16),
 }
 impl RunExerciseName {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             RunExerciseName::Run => 0,
@@ -21003,6 +25119,15 @@ pub enum WaterType {
     UnknownVariant(u8),
 }
 impl WaterType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             WaterType::Fresh => 0,
@@ -21058,6 +25183,12 @@ pub enum TissueModelType {
     UnknownVariant(u8),
 }
 impl TissueModelType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             TissueModelType::Zhl16c => 0,
@@ -21105,6 +25236,14 @@ pub enum DiveGasStatus {
     UnknownVariant(u8),
 }
 impl DiveGasStatus {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DiveGasStatus::Disabled => 0,
@@ -21159,6 +25298,13 @@ pub enum DiveAlarmType {
     UnknownVariant(u8),
 }
 impl DiveAlarmType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DiveAlarmType::Depth => 0,
@@ -21208,6 +25354,13 @@ pub enum DiveBacklightMode {
     UnknownVariant(u8),
 }
 impl DiveBacklightMode {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             DiveBacklightMode::AtDepth => 0,
@@ -21257,6 +25410,13 @@ pub enum FaveroProduct {
     UnknownVariant(u16),
 }
 impl FaveroProduct {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            10 => true,
+            12 => true,
+            _ => false,
+        }
+    }
     pub fn as_u16(self) -> u16 {
         match self {
             FaveroProduct::AssiomaUno => 10,
@@ -21307,6 +25467,14 @@ pub enum ClimbProEvent {
     UnknownVariant(u8),
 }
 impl ClimbProEvent {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             ClimbProEvent::Approach => 0,
@@ -21360,6 +25528,14 @@ pub enum TapSensitivity {
     UnknownVariant(u8),
 }
 impl TapSensitivity {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             TapSensitivity::High => 0,
@@ -21414,6 +25590,15 @@ pub enum RadarThreatLevelType {
     UnknownVariant(u8),
 }
 impl RadarThreatLevelType {
+    pub fn is_named_variant(value: i64) -> bool {
+        match value {
+            0 => true,
+            1 => true,
+            2 => true,
+            3 => true,
+            _ => false,
+        }
+    }
     pub fn as_u8(self) -> u8 {
         match self {
             RadarThreatLevelType::ThreatUnknown => 0,
@@ -21813,6 +25998,198 @@ impl FieldDataType {
             FieldDataType::ClimbProEvent => true,
             FieldDataType::TapSensitivity => true,
             FieldDataType::RadarThreatLevelType => true,
+            _ => false,
+        }
+    }
+    pub fn is_named_variant(self, value: i64) -> bool {
+        match self {
+            FieldDataType::File => File::is_named_variant(value),
+            FieldDataType::MesgNum => MesgNum::is_named_variant(value),
+            FieldDataType::Checksum => Checksum::is_named_variant(value),
+            FieldDataType::FileFlags => FileFlags::is_named_variant(value),
+            FieldDataType::MesgCount => MesgCount::is_named_variant(value),
+            FieldDataType::MessageIndex => MessageIndex::is_named_variant(value),
+            FieldDataType::DeviceIndex => DeviceIndex::is_named_variant(value),
+            FieldDataType::Gender => Gender::is_named_variant(value),
+            FieldDataType::Language => Language::is_named_variant(value),
+            FieldDataType::LanguageBits0 => LanguageBits0::is_named_variant(value),
+            FieldDataType::LanguageBits1 => LanguageBits1::is_named_variant(value),
+            FieldDataType::LanguageBits2 => LanguageBits2::is_named_variant(value),
+            FieldDataType::LanguageBits3 => LanguageBits3::is_named_variant(value),
+            FieldDataType::LanguageBits4 => LanguageBits4::is_named_variant(value),
+            FieldDataType::TimeZone => TimeZone::is_named_variant(value),
+            FieldDataType::DisplayMeasure => DisplayMeasure::is_named_variant(value),
+            FieldDataType::DisplayHeart => DisplayHeart::is_named_variant(value),
+            FieldDataType::DisplayPower => DisplayPower::is_named_variant(value),
+            FieldDataType::DisplayPosition => DisplayPosition::is_named_variant(value),
+            FieldDataType::Switch => Switch::is_named_variant(value),
+            FieldDataType::Sport => Sport::is_named_variant(value),
+            FieldDataType::SportBits0 => SportBits0::is_named_variant(value),
+            FieldDataType::SportBits1 => SportBits1::is_named_variant(value),
+            FieldDataType::SportBits2 => SportBits2::is_named_variant(value),
+            FieldDataType::SportBits3 => SportBits3::is_named_variant(value),
+            FieldDataType::SportBits4 => SportBits4::is_named_variant(value),
+            FieldDataType::SportBits5 => SportBits5::is_named_variant(value),
+            FieldDataType::SportBits6 => SportBits6::is_named_variant(value),
+            FieldDataType::SubSport => SubSport::is_named_variant(value),
+            FieldDataType::SportEvent => SportEvent::is_named_variant(value),
+            FieldDataType::Activity => Activity::is_named_variant(value),
+            FieldDataType::Intensity => Intensity::is_named_variant(value),
+            FieldDataType::SessionTrigger => SessionTrigger::is_named_variant(value),
+            FieldDataType::AutolapTrigger => AutolapTrigger::is_named_variant(value),
+            FieldDataType::LapTrigger => LapTrigger::is_named_variant(value),
+            FieldDataType::TimeMode => TimeMode::is_named_variant(value),
+            FieldDataType::BacklightMode => BacklightMode::is_named_variant(value),
+            FieldDataType::DateMode => DateMode::is_named_variant(value),
+            FieldDataType::BacklightTimeout => BacklightTimeout::is_named_variant(value),
+            FieldDataType::Event => Event::is_named_variant(value),
+            FieldDataType::EventType => EventType::is_named_variant(value),
+            FieldDataType::TimerTrigger => TimerTrigger::is_named_variant(value),
+            FieldDataType::FitnessEquipmentState => FitnessEquipmentState::is_named_variant(value),
+            FieldDataType::Tone => Tone::is_named_variant(value),
+            FieldDataType::Autoscroll => Autoscroll::is_named_variant(value),
+            FieldDataType::ActivityClass => ActivityClass::is_named_variant(value),
+            FieldDataType::HrZoneCalc => HrZoneCalc::is_named_variant(value),
+            FieldDataType::PwrZoneCalc => PwrZoneCalc::is_named_variant(value),
+            FieldDataType::WktStepDuration => WktStepDuration::is_named_variant(value),
+            FieldDataType::WktStepTarget => WktStepTarget::is_named_variant(value),
+            FieldDataType::Goal => Goal::is_named_variant(value),
+            FieldDataType::GoalRecurrence => GoalRecurrence::is_named_variant(value),
+            FieldDataType::GoalSource => GoalSource::is_named_variant(value),
+            FieldDataType::Schedule => Schedule::is_named_variant(value),
+            FieldDataType::CoursePoint => CoursePoint::is_named_variant(value),
+            FieldDataType::Manufacturer => Manufacturer::is_named_variant(value),
+            FieldDataType::GarminProduct => GarminProduct::is_named_variant(value),
+            FieldDataType::AntplusDeviceType => AntplusDeviceType::is_named_variant(value),
+            FieldDataType::AntNetwork => AntNetwork::is_named_variant(value),
+            FieldDataType::WorkoutCapabilities => WorkoutCapabilities::is_named_variant(value),
+            FieldDataType::BatteryStatus => BatteryStatus::is_named_variant(value),
+            FieldDataType::HrType => HrType::is_named_variant(value),
+            FieldDataType::CourseCapabilities => CourseCapabilities::is_named_variant(value),
+            FieldDataType::Weight => Weight::is_named_variant(value),
+            FieldDataType::WorkoutHr => WorkoutHr::is_named_variant(value),
+            FieldDataType::WorkoutPower => WorkoutPower::is_named_variant(value),
+            FieldDataType::BpStatus => BpStatus::is_named_variant(value),
+            FieldDataType::UserLocalId => UserLocalId::is_named_variant(value),
+            FieldDataType::SwimStroke => SwimStroke::is_named_variant(value),
+            FieldDataType::ActivityType => ActivityType::is_named_variant(value),
+            FieldDataType::ActivitySubtype => ActivitySubtype::is_named_variant(value),
+            FieldDataType::ActivityLevel => ActivityLevel::is_named_variant(value),
+            FieldDataType::Side => Side::is_named_variant(value),
+            FieldDataType::LeftRightBalance => LeftRightBalance::is_named_variant(value),
+            FieldDataType::LeftRightBalance100 => LeftRightBalance100::is_named_variant(value),
+            FieldDataType::LengthType => LengthType::is_named_variant(value),
+            FieldDataType::DayOfWeek => DayOfWeek::is_named_variant(value),
+            FieldDataType::ConnectivityCapabilities => {
+                ConnectivityCapabilities::is_named_variant(value)
+            }
+            FieldDataType::WeatherReport => WeatherReport::is_named_variant(value),
+            FieldDataType::WeatherStatus => WeatherStatus::is_named_variant(value),
+            FieldDataType::WeatherSeverity => WeatherSeverity::is_named_variant(value),
+            FieldDataType::WeatherSevereType => WeatherSevereType::is_named_variant(value),
+            FieldDataType::StrokeType => StrokeType::is_named_variant(value),
+            FieldDataType::BodyLocation => BodyLocation::is_named_variant(value),
+            FieldDataType::SegmentLapStatus => SegmentLapStatus::is_named_variant(value),
+            FieldDataType::SegmentLeaderboardType => {
+                SegmentLeaderboardType::is_named_variant(value)
+            }
+            FieldDataType::SegmentDeleteStatus => SegmentDeleteStatus::is_named_variant(value),
+            FieldDataType::SegmentSelectionType => SegmentSelectionType::is_named_variant(value),
+            FieldDataType::SourceType => SourceType::is_named_variant(value),
+            FieldDataType::DisplayOrientation => DisplayOrientation::is_named_variant(value),
+            FieldDataType::WorkoutEquipment => WorkoutEquipment::is_named_variant(value),
+            FieldDataType::WatchfaceMode => WatchfaceMode::is_named_variant(value),
+            FieldDataType::DigitalWatchfaceLayout => {
+                DigitalWatchfaceLayout::is_named_variant(value)
+            }
+            FieldDataType::AnalogWatchfaceLayout => AnalogWatchfaceLayout::is_named_variant(value),
+            FieldDataType::RiderPositionType => RiderPositionType::is_named_variant(value),
+            FieldDataType::PowerPhaseType => PowerPhaseType::is_named_variant(value),
+            FieldDataType::CameraEventType => CameraEventType::is_named_variant(value),
+            FieldDataType::SensorType => SensorType::is_named_variant(value),
+            FieldDataType::BikeLightNetworkConfigType => {
+                BikeLightNetworkConfigType::is_named_variant(value)
+            }
+            FieldDataType::CommTimeoutType => CommTimeoutType::is_named_variant(value),
+            FieldDataType::CameraOrientationType => CameraOrientationType::is_named_variant(value),
+            FieldDataType::AttitudeStage => AttitudeStage::is_named_variant(value),
+            FieldDataType::AttitudeValidity => AttitudeValidity::is_named_variant(value),
+            FieldDataType::AutoSyncFrequency => AutoSyncFrequency::is_named_variant(value),
+            FieldDataType::ExdLayout => ExdLayout::is_named_variant(value),
+            FieldDataType::ExdDisplayType => ExdDisplayType::is_named_variant(value),
+            FieldDataType::ExdDataUnits => ExdDataUnits::is_named_variant(value),
+            FieldDataType::ExdQualifiers => ExdQualifiers::is_named_variant(value),
+            FieldDataType::ExdDescriptors => ExdDescriptors::is_named_variant(value),
+            FieldDataType::AutoActivityDetect => AutoActivityDetect::is_named_variant(value),
+            FieldDataType::SupportedExdScreenLayouts => {
+                SupportedExdScreenLayouts::is_named_variant(value)
+            }
+            FieldDataType::FitBaseType => FitBaseType::is_named_variant(value),
+            FieldDataType::TurnType => TurnType::is_named_variant(value),
+            FieldDataType::BikeLightBeamAngleMode => {
+                BikeLightBeamAngleMode::is_named_variant(value)
+            }
+            FieldDataType::FitBaseUnit => FitBaseUnit::is_named_variant(value),
+            FieldDataType::SetType => SetType::is_named_variant(value),
+            FieldDataType::ExerciseCategory => ExerciseCategory::is_named_variant(value),
+            FieldDataType::BenchPressExerciseName => {
+                BenchPressExerciseName::is_named_variant(value)
+            }
+            FieldDataType::CalfRaiseExerciseName => CalfRaiseExerciseName::is_named_variant(value),
+            FieldDataType::CardioExerciseName => CardioExerciseName::is_named_variant(value),
+            FieldDataType::CarryExerciseName => CarryExerciseName::is_named_variant(value),
+            FieldDataType::ChopExerciseName => ChopExerciseName::is_named_variant(value),
+            FieldDataType::CoreExerciseName => CoreExerciseName::is_named_variant(value),
+            FieldDataType::CrunchExerciseName => CrunchExerciseName::is_named_variant(value),
+            FieldDataType::CurlExerciseName => CurlExerciseName::is_named_variant(value),
+            FieldDataType::DeadliftExerciseName => DeadliftExerciseName::is_named_variant(value),
+            FieldDataType::FlyeExerciseName => FlyeExerciseName::is_named_variant(value),
+            FieldDataType::HipRaiseExerciseName => HipRaiseExerciseName::is_named_variant(value),
+            FieldDataType::HipStabilityExerciseName => {
+                HipStabilityExerciseName::is_named_variant(value)
+            }
+            FieldDataType::HipSwingExerciseName => HipSwingExerciseName::is_named_variant(value),
+            FieldDataType::HyperextensionExerciseName => {
+                HyperextensionExerciseName::is_named_variant(value)
+            }
+            FieldDataType::LateralRaiseExerciseName => {
+                LateralRaiseExerciseName::is_named_variant(value)
+            }
+            FieldDataType::LegCurlExerciseName => LegCurlExerciseName::is_named_variant(value),
+            FieldDataType::LegRaiseExerciseName => LegRaiseExerciseName::is_named_variant(value),
+            FieldDataType::LungeExerciseName => LungeExerciseName::is_named_variant(value),
+            FieldDataType::OlympicLiftExerciseName => {
+                OlympicLiftExerciseName::is_named_variant(value)
+            }
+            FieldDataType::PlankExerciseName => PlankExerciseName::is_named_variant(value),
+            FieldDataType::PlyoExerciseName => PlyoExerciseName::is_named_variant(value),
+            FieldDataType::PullUpExerciseName => PullUpExerciseName::is_named_variant(value),
+            FieldDataType::PushUpExerciseName => PushUpExerciseName::is_named_variant(value),
+            FieldDataType::RowExerciseName => RowExerciseName::is_named_variant(value),
+            FieldDataType::ShoulderPressExerciseName => {
+                ShoulderPressExerciseName::is_named_variant(value)
+            }
+            FieldDataType::ShoulderStabilityExerciseName => {
+                ShoulderStabilityExerciseName::is_named_variant(value)
+            }
+            FieldDataType::ShrugExerciseName => ShrugExerciseName::is_named_variant(value),
+            FieldDataType::SitUpExerciseName => SitUpExerciseName::is_named_variant(value),
+            FieldDataType::SquatExerciseName => SquatExerciseName::is_named_variant(value),
+            FieldDataType::TotalBodyExerciseName => TotalBodyExerciseName::is_named_variant(value),
+            FieldDataType::TricepsExtensionExerciseName => {
+                TricepsExtensionExerciseName::is_named_variant(value)
+            }
+            FieldDataType::WarmUpExerciseName => WarmUpExerciseName::is_named_variant(value),
+            FieldDataType::RunExerciseName => RunExerciseName::is_named_variant(value),
+            FieldDataType::WaterType => WaterType::is_named_variant(value),
+            FieldDataType::TissueModelType => TissueModelType::is_named_variant(value),
+            FieldDataType::DiveGasStatus => DiveGasStatus::is_named_variant(value),
+            FieldDataType::DiveAlarmType => DiveAlarmType::is_named_variant(value),
+            FieldDataType::DiveBacklightMode => DiveBacklightMode::is_named_variant(value),
+            FieldDataType::FaveroProduct => FaveroProduct::is_named_variant(value),
+            FieldDataType::ClimbProEvent => ClimbProEvent::is_named_variant(value),
+            FieldDataType::TapSensitivity => TapSensitivity::is_named_variant(value),
+            FieldDataType::RadarThreatLevelType => RadarThreatLevelType::is_named_variant(value),
             _ => false,
         }
     }

--- a/fitparser/src/profile/field_types.rs
+++ b/fitparser/src/profile/field_types.rs
@@ -267,7 +267,7 @@ pub enum MesgNum {
     MfgRangeMin,
     /// 0xFF00 - 0xFFFE reserved for manufacturer specific messages
     MfgRangeMax,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl MesgNum {
     pub fn is_named_variant(value: i64) -> bool {
@@ -459,7 +459,7 @@ impl MesgNum {
             MesgNum::DeviceAuxBatteryInfo => 375,
             MesgNum::MfgRangeMin => 65280,
             MesgNum::MfgRangeMax => 65534,
-            MesgNum::UnknownVariant(value) => value,
+            MesgNum::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -560,7 +560,7 @@ impl fmt::Display for MesgNum {
             MesgNum::DeviceAuxBatteryInfo => write!(f, "device_aux_battery_info"),
             MesgNum::MfgRangeMin => write!(f, "mfg_range_min"),
             MesgNum::MfgRangeMax => write!(f, "mfg_range_max"),
-            MesgNum::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            MesgNum::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -658,7 +658,7 @@ impl convert::From<u16> for MesgNum {
             375 => MesgNum::DeviceAuxBatteryInfo,
             65280 => MesgNum::MfgRangeMin,
             65534 => MesgNum::MfgRangeMax,
-            _ => MesgNum::UnknownVariant(value),
+            _ => MesgNum::Value(value),
         }
     }
 }
@@ -672,7 +672,10 @@ impl Serialize for MesgNum {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            MesgNum::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -681,7 +684,7 @@ pub enum Checksum {
     Clear,
     /// Set to mark checksum as valid if computes to invalid values 0 or 0xFF. Checksum can also be set to ok to save encoding computation time.
     Ok,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl Checksum {
     pub fn is_named_variant(value: i64) -> bool {
@@ -695,7 +698,7 @@ impl Checksum {
         match self {
             Checksum::Clear => 0,
             Checksum::Ok => 1,
-            Checksum::UnknownVariant(value) => value,
+            Checksum::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -707,7 +710,7 @@ impl fmt::Display for Checksum {
         match &self {
             Checksum::Clear => write!(f, "clear"),
             Checksum::Ok => write!(f, "ok"),
-            Checksum::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            Checksum::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -716,7 +719,7 @@ impl convert::From<u8> for Checksum {
         match value {
             0 => Checksum::Clear,
             1 => Checksum::Ok,
-            _ => Checksum::UnknownVariant(value),
+            _ => Checksum::Value(value),
         }
     }
 }
@@ -730,7 +733,10 @@ impl Serialize for Checksum {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            Checksum::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -738,7 +744,7 @@ pub enum FileFlags {
     Read,
     Write,
     Erase,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl FileFlags {
     pub fn is_named_variant(value: i64) -> bool {
@@ -754,7 +760,7 @@ impl FileFlags {
             FileFlags::Read => 2,
             FileFlags::Write => 4,
             FileFlags::Erase => 8,
-            FileFlags::UnknownVariant(value) => value,
+            FileFlags::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -767,7 +773,7 @@ impl fmt::Display for FileFlags {
             FileFlags::Read => write!(f, "read"),
             FileFlags::Write => write!(f, "write"),
             FileFlags::Erase => write!(f, "erase"),
-            FileFlags::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            FileFlags::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -777,7 +783,7 @@ impl convert::From<u8> for FileFlags {
             2 => FileFlags::Read,
             4 => FileFlags::Write,
             8 => FileFlags::Erase,
-            _ => FileFlags::UnknownVariant(value),
+            _ => FileFlags::Value(value),
         }
     }
 }
@@ -791,7 +797,10 @@ impl Serialize for FileFlags {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            FileFlags::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -860,7 +869,7 @@ impl Serialize for MesgCount {
 pub enum DateTime {
     /// if date_time is < 0x10000000 then it is system time (seconds from device power on)
     Min,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl DateTime {
     pub fn is_named_variant(value: i64) -> bool {
@@ -872,7 +881,7 @@ impl DateTime {
     pub fn as_u32(self) -> u32 {
         match self {
             DateTime::Min => 268435456,
-            DateTime::UnknownVariant(value) => value,
+            DateTime::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -883,7 +892,7 @@ impl fmt::Display for DateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             DateTime::Min => write!(f, "min"),
-            DateTime::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            DateTime::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -891,7 +900,7 @@ impl convert::From<u32> for DateTime {
     fn from(value: u32) -> Self {
         match value {
             268435456 => DateTime::Min,
-            _ => DateTime::UnknownVariant(value),
+            _ => DateTime::Value(value),
         }
     }
 }
@@ -905,7 +914,10 @@ impl Serialize for DateTime {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            DateTime::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// seconds since 00:00 Dec 31 1989 in local time zone
@@ -913,7 +925,7 @@ impl Serialize for DateTime {
 pub enum LocalDateTime {
     /// if date_time is < 0x10000000 then it is system time (seconds from device power on)
     Min,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl LocalDateTime {
     pub fn is_named_variant(value: i64) -> bool {
@@ -925,7 +937,7 @@ impl LocalDateTime {
     pub fn as_u32(self) -> u32 {
         match self {
             LocalDateTime::Min => 268435456,
-            LocalDateTime::UnknownVariant(value) => value,
+            LocalDateTime::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -936,7 +948,7 @@ impl fmt::Display for LocalDateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             LocalDateTime::Min => write!(f, "min"),
-            LocalDateTime::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LocalDateTime::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -944,7 +956,7 @@ impl convert::From<u32> for LocalDateTime {
     fn from(value: u32) -> Self {
         match value {
             268435456 => LocalDateTime::Min,
-            _ => LocalDateTime::UnknownVariant(value),
+            _ => LocalDateTime::Value(value),
         }
     }
 }
@@ -958,7 +970,10 @@ impl Serialize for LocalDateTime {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LocalDateTime::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -969,7 +984,7 @@ pub enum MessageIndex {
     Reserved,
     /// message is selected if set
     Selected,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl MessageIndex {
     pub fn is_named_variant(value: i64) -> bool {
@@ -985,7 +1000,7 @@ impl MessageIndex {
             MessageIndex::Mask => 4095,
             MessageIndex::Reserved => 28672,
             MessageIndex::Selected => 32768,
-            MessageIndex::UnknownVariant(value) => value,
+            MessageIndex::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -998,7 +1013,7 @@ impl fmt::Display for MessageIndex {
             MessageIndex::Mask => write!(f, "mask"),
             MessageIndex::Reserved => write!(f, "reserved"),
             MessageIndex::Selected => write!(f, "selected"),
-            MessageIndex::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            MessageIndex::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -1008,7 +1023,7 @@ impl convert::From<u16> for MessageIndex {
             4095 => MessageIndex::Mask,
             28672 => MessageIndex::Reserved,
             32768 => MessageIndex::Selected,
-            _ => MessageIndex::UnknownVariant(value),
+            _ => MessageIndex::Value(value),
         }
     }
 }
@@ -1022,14 +1037,17 @@ impl Serialize for MessageIndex {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            MessageIndex::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum DeviceIndex {
     /// Creator of the file is always device index 0.
     Creator,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl DeviceIndex {
     pub fn is_named_variant(value: i64) -> bool {
@@ -1041,7 +1059,7 @@ impl DeviceIndex {
     pub fn as_u8(self) -> u8 {
         match self {
             DeviceIndex::Creator => 0,
-            DeviceIndex::UnknownVariant(value) => value,
+            DeviceIndex::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -1052,7 +1070,7 @@ impl fmt::Display for DeviceIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             DeviceIndex::Creator => write!(f, "creator"),
-            DeviceIndex::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            DeviceIndex::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -1060,7 +1078,7 @@ impl convert::From<u8> for DeviceIndex {
     fn from(value: u8) -> Self {
         match value {
             0 => DeviceIndex::Creator,
-            _ => DeviceIndex::UnknownVariant(value),
+            _ => DeviceIndex::Value(value),
         }
     }
 }
@@ -1074,7 +1092,10 @@ impl Serialize for DeviceIndex {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            DeviceIndex::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1385,7 +1406,7 @@ pub enum LanguageBits0 {
     Croatian,
     Czech,
     Danish,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl LanguageBits0 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -1411,7 +1432,7 @@ impl LanguageBits0 {
             LanguageBits0::Croatian => 32,
             LanguageBits0::Czech => 64,
             LanguageBits0::Danish => 128,
-            LanguageBits0::UnknownVariant(value) => value,
+            LanguageBits0::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -1429,7 +1450,7 @@ impl fmt::Display for LanguageBits0 {
             LanguageBits0::Croatian => write!(f, "croatian"),
             LanguageBits0::Czech => write!(f, "czech"),
             LanguageBits0::Danish => write!(f, "danish"),
-            LanguageBits0::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LanguageBits0::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -1444,7 +1465,7 @@ impl convert::From<u8> for LanguageBits0 {
             32 => LanguageBits0::Croatian,
             64 => LanguageBits0::Czech,
             128 => LanguageBits0::Danish,
-            _ => LanguageBits0::UnknownVariant(value),
+            _ => LanguageBits0::Value(value),
         }
     }
 }
@@ -1458,7 +1479,10 @@ impl Serialize for LanguageBits0 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LanguageBits0::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1471,7 +1495,7 @@ pub enum LanguageBits1 {
     Polish,
     Portuguese,
     Slovakian,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl LanguageBits1 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -1497,7 +1521,7 @@ impl LanguageBits1 {
             LanguageBits1::Polish => 32,
             LanguageBits1::Portuguese => 64,
             LanguageBits1::Slovakian => 128,
-            LanguageBits1::UnknownVariant(value) => value,
+            LanguageBits1::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -1515,7 +1539,7 @@ impl fmt::Display for LanguageBits1 {
             LanguageBits1::Polish => write!(f, "polish"),
             LanguageBits1::Portuguese => write!(f, "portuguese"),
             LanguageBits1::Slovakian => write!(f, "slovakian"),
-            LanguageBits1::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LanguageBits1::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -1530,7 +1554,7 @@ impl convert::From<u8> for LanguageBits1 {
             32 => LanguageBits1::Polish,
             64 => LanguageBits1::Portuguese,
             128 => LanguageBits1::Slovakian,
-            _ => LanguageBits1::UnknownVariant(value),
+            _ => LanguageBits1::Value(value),
         }
     }
 }
@@ -1544,7 +1568,10 @@ impl Serialize for LanguageBits1 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LanguageBits1::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1557,7 +1584,7 @@ pub enum LanguageBits2 {
     Ukrainian,
     Arabic,
     Farsi,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl LanguageBits2 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -1583,7 +1610,7 @@ impl LanguageBits2 {
             LanguageBits2::Ukrainian => 32,
             LanguageBits2::Arabic => 64,
             LanguageBits2::Farsi => 128,
-            LanguageBits2::UnknownVariant(value) => value,
+            LanguageBits2::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -1601,7 +1628,7 @@ impl fmt::Display for LanguageBits2 {
             LanguageBits2::Ukrainian => write!(f, "ukrainian"),
             LanguageBits2::Arabic => write!(f, "arabic"),
             LanguageBits2::Farsi => write!(f, "farsi"),
-            LanguageBits2::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LanguageBits2::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -1616,7 +1643,7 @@ impl convert::From<u8> for LanguageBits2 {
             32 => LanguageBits2::Ukrainian,
             64 => LanguageBits2::Arabic,
             128 => LanguageBits2::Farsi,
-            _ => LanguageBits2::UnknownVariant(value),
+            _ => LanguageBits2::Value(value),
         }
     }
 }
@@ -1630,7 +1657,10 @@ impl Serialize for LanguageBits2 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LanguageBits2::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1643,7 +1673,7 @@ pub enum LanguageBits3 {
     Taiwanese,
     Thai,
     Hebrew,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl LanguageBits3 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -1669,7 +1699,7 @@ impl LanguageBits3 {
             LanguageBits3::Taiwanese => 32,
             LanguageBits3::Thai => 64,
             LanguageBits3::Hebrew => 128,
-            LanguageBits3::UnknownVariant(value) => value,
+            LanguageBits3::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -1687,7 +1717,7 @@ impl fmt::Display for LanguageBits3 {
             LanguageBits3::Taiwanese => write!(f, "taiwanese"),
             LanguageBits3::Thai => write!(f, "thai"),
             LanguageBits3::Hebrew => write!(f, "hebrew"),
-            LanguageBits3::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LanguageBits3::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -1702,7 +1732,7 @@ impl convert::From<u8> for LanguageBits3 {
             32 => LanguageBits3::Taiwanese,
             64 => LanguageBits3::Thai,
             128 => LanguageBits3::Hebrew,
-            _ => LanguageBits3::UnknownVariant(value),
+            _ => LanguageBits3::Value(value),
         }
     }
 }
@@ -1716,7 +1746,10 @@ impl Serialize for LanguageBits3 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LanguageBits3::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1727,7 +1760,7 @@ pub enum LanguageBits4 {
     Vietnamese,
     Burmese,
     Mongolian,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl LanguageBits4 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -1749,7 +1782,7 @@ impl LanguageBits4 {
             LanguageBits4::Vietnamese => 8,
             LanguageBits4::Burmese => 16,
             LanguageBits4::Mongolian => 32,
-            LanguageBits4::UnknownVariant(value) => value,
+            LanguageBits4::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -1765,7 +1798,7 @@ impl fmt::Display for LanguageBits4 {
             LanguageBits4::Vietnamese => write!(f, "vietnamese"),
             LanguageBits4::Burmese => write!(f, "burmese"),
             LanguageBits4::Mongolian => write!(f, "mongolian"),
-            LanguageBits4::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LanguageBits4::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -1778,7 +1811,7 @@ impl convert::From<u8> for LanguageBits4 {
             8 => LanguageBits4::Vietnamese,
             16 => LanguageBits4::Burmese,
             32 => LanguageBits4::Mongolian,
-            _ => LanguageBits4::UnknownVariant(value),
+            _ => LanguageBits4::Value(value),
         }
     }
 }
@@ -1792,7 +1825,10 @@ impl Serialize for LanguageBits4 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LanguageBits4::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -3223,7 +3259,7 @@ pub enum SportBits0 {
     Swimming,
     Basketball,
     Soccer,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SportBits0 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -3249,7 +3285,7 @@ impl SportBits0 {
             SportBits0::Swimming => 32,
             SportBits0::Basketball => 64,
             SportBits0::Soccer => 128,
-            SportBits0::UnknownVariant(value) => value,
+            SportBits0::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -3267,7 +3303,7 @@ impl fmt::Display for SportBits0 {
             SportBits0::Swimming => write!(f, "swimming"),
             SportBits0::Basketball => write!(f, "basketball"),
             SportBits0::Soccer => write!(f, "soccer"),
-            SportBits0::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SportBits0::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -3282,7 +3318,7 @@ impl convert::From<u8> for SportBits0 {
             32 => SportBits0::Swimming,
             64 => SportBits0::Basketball,
             128 => SportBits0::Soccer,
-            _ => SportBits0::UnknownVariant(value),
+            _ => SportBits0::Value(value),
         }
     }
 }
@@ -3296,7 +3332,10 @@ impl Serialize for SportBits0 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SportBits0::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// Bit field corresponding to sport enum type (1 << (sport-8)).
@@ -3310,7 +3349,7 @@ pub enum SportBits1 {
     AlpineSkiing,
     Snowboarding,
     Rowing,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SportBits1 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -3336,7 +3375,7 @@ impl SportBits1 {
             SportBits1::AlpineSkiing => 32,
             SportBits1::Snowboarding => 64,
             SportBits1::Rowing => 128,
-            SportBits1::UnknownVariant(value) => value,
+            SportBits1::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -3354,7 +3393,7 @@ impl fmt::Display for SportBits1 {
             SportBits1::AlpineSkiing => write!(f, "alpine_skiing"),
             SportBits1::Snowboarding => write!(f, "snowboarding"),
             SportBits1::Rowing => write!(f, "rowing"),
-            SportBits1::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SportBits1::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -3369,7 +3408,7 @@ impl convert::From<u8> for SportBits1 {
             32 => SportBits1::AlpineSkiing,
             64 => SportBits1::Snowboarding,
             128 => SportBits1::Rowing,
-            _ => SportBits1::UnknownVariant(value),
+            _ => SportBits1::Value(value),
         }
     }
 }
@@ -3383,7 +3422,10 @@ impl Serialize for SportBits1 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SportBits1::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// Bit field corresponding to sport enum type (1 << (sport-16)).
@@ -3397,7 +3439,7 @@ pub enum SportBits2 {
     EBiking,
     Motorcycling,
     Boating,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SportBits2 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -3423,7 +3465,7 @@ impl SportBits2 {
             SportBits2::EBiking => 32,
             SportBits2::Motorcycling => 64,
             SportBits2::Boating => 128,
-            SportBits2::UnknownVariant(value) => value,
+            SportBits2::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -3441,7 +3483,7 @@ impl fmt::Display for SportBits2 {
             SportBits2::EBiking => write!(f, "e_biking"),
             SportBits2::Motorcycling => write!(f, "motorcycling"),
             SportBits2::Boating => write!(f, "boating"),
-            SportBits2::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SportBits2::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -3456,7 +3498,7 @@ impl convert::From<u8> for SportBits2 {
             32 => SportBits2::EBiking,
             64 => SportBits2::Motorcycling,
             128 => SportBits2::Boating,
-            _ => SportBits2::UnknownVariant(value),
+            _ => SportBits2::Value(value),
         }
     }
 }
@@ -3470,7 +3512,10 @@ impl Serialize for SportBits2 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SportBits2::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// Bit field corresponding to sport enum type (1 << (sport-24)).
@@ -3484,7 +3529,7 @@ pub enum SportBits3 {
     Fishing,
     InlineSkating,
     RockClimbing,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SportBits3 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -3510,7 +3555,7 @@ impl SportBits3 {
             SportBits3::Fishing => 32,
             SportBits3::InlineSkating => 64,
             SportBits3::RockClimbing => 128,
-            SportBits3::UnknownVariant(value) => value,
+            SportBits3::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -3528,7 +3573,7 @@ impl fmt::Display for SportBits3 {
             SportBits3::Fishing => write!(f, "fishing"),
             SportBits3::InlineSkating => write!(f, "inline_skating"),
             SportBits3::RockClimbing => write!(f, "rock_climbing"),
-            SportBits3::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SportBits3::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -3543,7 +3588,7 @@ impl convert::From<u8> for SportBits3 {
             32 => SportBits3::Fishing,
             64 => SportBits3::InlineSkating,
             128 => SportBits3::RockClimbing,
-            _ => SportBits3::UnknownVariant(value),
+            _ => SportBits3::Value(value),
         }
     }
 }
@@ -3557,7 +3602,10 @@ impl Serialize for SportBits3 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SportBits3::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// Bit field corresponding to sport enum type (1 << (sport-32)).
@@ -3571,7 +3619,7 @@ pub enum SportBits4 {
     StandUpPaddleboarding,
     Surfing,
     Wakeboarding,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SportBits4 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -3597,7 +3645,7 @@ impl SportBits4 {
             SportBits4::StandUpPaddleboarding => 32,
             SportBits4::Surfing => 64,
             SportBits4::Wakeboarding => 128,
-            SportBits4::UnknownVariant(value) => value,
+            SportBits4::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -3615,7 +3663,7 @@ impl fmt::Display for SportBits4 {
             SportBits4::StandUpPaddleboarding => write!(f, "stand_up_paddleboarding"),
             SportBits4::Surfing => write!(f, "surfing"),
             SportBits4::Wakeboarding => write!(f, "wakeboarding"),
-            SportBits4::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SportBits4::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -3630,7 +3678,7 @@ impl convert::From<u8> for SportBits4 {
             32 => SportBits4::StandUpPaddleboarding,
             64 => SportBits4::Surfing,
             128 => SportBits4::Wakeboarding,
-            _ => SportBits4::UnknownVariant(value),
+            _ => SportBits4::Value(value),
         }
     }
 }
@@ -3644,7 +3692,10 @@ impl Serialize for SportBits4 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SportBits4::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// Bit field corresponding to sport enum type (1 << (sport-40)).
@@ -3658,7 +3709,7 @@ pub enum SportBits5 {
     Tactical,
     Jumpmaster,
     Boxing,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SportBits5 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -3684,7 +3735,7 @@ impl SportBits5 {
             SportBits5::Tactical => 32,
             SportBits5::Jumpmaster => 64,
             SportBits5::Boxing => 128,
-            SportBits5::UnknownVariant(value) => value,
+            SportBits5::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -3702,7 +3753,7 @@ impl fmt::Display for SportBits5 {
             SportBits5::Tactical => write!(f, "tactical"),
             SportBits5::Jumpmaster => write!(f, "jumpmaster"),
             SportBits5::Boxing => write!(f, "boxing"),
-            SportBits5::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SportBits5::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -3717,7 +3768,7 @@ impl convert::From<u8> for SportBits5 {
             32 => SportBits5::Tactical,
             64 => SportBits5::Jumpmaster,
             128 => SportBits5::Boxing,
-            _ => SportBits5::UnknownVariant(value),
+            _ => SportBits5::Value(value),
         }
     }
 }
@@ -3731,14 +3782,17 @@ impl Serialize for SportBits5 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SportBits5::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// Bit field corresponding to sport enum type (1 << (sport-48)).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SportBits6 {
     FloorClimbing,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SportBits6 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -3750,7 +3804,7 @@ impl SportBits6 {
     pub fn as_u8(self) -> u8 {
         match self {
             SportBits6::FloorClimbing => 1,
-            SportBits6::UnknownVariant(value) => value,
+            SportBits6::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -3761,7 +3815,7 @@ impl fmt::Display for SportBits6 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             SportBits6::FloorClimbing => write!(f, "floor_climbing"),
-            SportBits6::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SportBits6::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -3769,7 +3823,7 @@ impl convert::From<u8> for SportBits6 {
     fn from(value: u8) -> Self {
         match value {
             1 => SportBits6::FloorClimbing,
-            _ => SportBits6::UnknownVariant(value),
+            _ => SportBits6::Value(value),
         }
     }
 }
@@ -3783,7 +3837,10 @@ impl Serialize for SportBits6 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SportBits6::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -4911,7 +4968,7 @@ impl Serialize for DateMode {
 pub enum BacklightTimeout {
     /// Backlight stays on forever.
     Infinite,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl BacklightTimeout {
     pub fn is_named_variant(value: i64) -> bool {
@@ -4923,7 +4980,7 @@ impl BacklightTimeout {
     pub fn as_u8(self) -> u8 {
         match self {
             BacklightTimeout::Infinite => 0,
-            BacklightTimeout::UnknownVariant(value) => value,
+            BacklightTimeout::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -4934,7 +4991,7 @@ impl fmt::Display for BacklightTimeout {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             BacklightTimeout::Infinite => write!(f, "infinite"),
-            BacklightTimeout::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            BacklightTimeout::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -4942,7 +4999,7 @@ impl convert::From<u8> for BacklightTimeout {
     fn from(value: u8) -> Self {
         match value {
             0 => BacklightTimeout::Infinite,
-            _ => BacklightTimeout::UnknownVariant(value),
+            _ => BacklightTimeout::Value(value),
         }
     }
 }
@@ -4956,7 +5013,10 @@ impl Serialize for BacklightTimeout {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            BacklightTimeout::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -6896,7 +6956,7 @@ pub enum Manufacturer {
     Fazua,
     OrekaTraining,
     Actigraphcorp,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl Manufacturer {
     pub fn is_named_variant(value: i64) -> bool {
@@ -7320,7 +7380,7 @@ impl Manufacturer {
             Manufacturer::Fazua => 318,
             Manufacturer::OrekaTraining => 319,
             Manufacturer::Actigraphcorp => 5759,
-            Manufacturer::UnknownVariant(value) => value,
+            Manufacturer::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -7537,7 +7597,7 @@ impl fmt::Display for Manufacturer {
             Manufacturer::Fazua => write!(f, "fazua"),
             Manufacturer::OrekaTraining => write!(f, "oreka_training"),
             Manufacturer::Actigraphcorp => write!(f, "actigraphcorp"),
-            Manufacturer::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            Manufacturer::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -7751,7 +7811,7 @@ impl convert::From<u16> for Manufacturer {
             318 => Manufacturer::Fazua,
             319 => Manufacturer::OrekaTraining,
             5759 => Manufacturer::Actigraphcorp,
-            _ => Manufacturer::UnknownVariant(value),
+            _ => Manufacturer::Value(value),
         }
     }
 }
@@ -7765,7 +7825,10 @@ impl Serialize for Manufacturer {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            Manufacturer::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -8201,7 +8264,7 @@ pub enum GarminProduct {
     AndroidAntplusPlugin,
     /// Garmin Connect website
     Connect,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl GarminProduct {
     pub fn is_named_variant(value: i64) -> bool {
@@ -8995,7 +9058,7 @@ impl GarminProduct {
             GarminProduct::ConnectiqSimulator => 65531,
             GarminProduct::AndroidAntplusPlugin => 65532,
             GarminProduct::Connect => 65534,
-            GarminProduct::UnknownVariant(value) => value,
+            GarminProduct::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -9405,7 +9468,7 @@ impl fmt::Display for GarminProduct {
             GarminProduct::ConnectiqSimulator => write!(f, "connectiq_simulator"),
             GarminProduct::AndroidAntplusPlugin => write!(f, "android_antplus_plugin"),
             GarminProduct::Connect => write!(f, "connect"),
-            GarminProduct::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            GarminProduct::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -9804,7 +9867,7 @@ impl convert::From<u16> for GarminProduct {
             65531 => GarminProduct::ConnectiqSimulator,
             65532 => GarminProduct::AndroidAntplusPlugin,
             65534 => GarminProduct::Connect,
-            _ => GarminProduct::UnknownVariant(value),
+            _ => GarminProduct::Value(value),
         }
     }
 }
@@ -9818,7 +9881,10 @@ impl Serialize for GarminProduct {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            GarminProduct::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -9848,7 +9914,7 @@ pub enum AntplusDeviceType {
     BikeCadence,
     BikeSpeed,
     StrideSpeedDistance,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl AntplusDeviceType {
     pub fn is_named_variant(value: i64) -> bool {
@@ -9908,7 +9974,7 @@ impl AntplusDeviceType {
             AntplusDeviceType::BikeCadence => 122,
             AntplusDeviceType::BikeSpeed => 123,
             AntplusDeviceType::StrideSpeedDistance => 124,
-            AntplusDeviceType::UnknownVariant(value) => value,
+            AntplusDeviceType::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -9943,7 +10009,7 @@ impl fmt::Display for AntplusDeviceType {
             AntplusDeviceType::BikeCadence => write!(f, "bike_cadence"),
             AntplusDeviceType::BikeSpeed => write!(f, "bike_speed"),
             AntplusDeviceType::StrideSpeedDistance => write!(f, "stride_speed_distance"),
-            AntplusDeviceType::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            AntplusDeviceType::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -9975,7 +10041,7 @@ impl convert::From<u8> for AntplusDeviceType {
             122 => AntplusDeviceType::BikeCadence,
             123 => AntplusDeviceType::BikeSpeed,
             124 => AntplusDeviceType::StrideSpeedDistance,
-            _ => AntplusDeviceType::UnknownVariant(value),
+            _ => AntplusDeviceType::Value(value),
         }
     }
 }
@@ -9989,7 +10055,10 @@ impl Serialize for AntplusDeviceType {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            AntplusDeviceType::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -10082,7 +10151,7 @@ pub enum WorkoutCapabilities {
     /// Resistance source required for workout step.
     Resistance,
     Protected,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl WorkoutCapabilities {
     pub fn is_named_variant(value: i64) -> bool {
@@ -10120,7 +10189,7 @@ impl WorkoutCapabilities {
             WorkoutCapabilities::Grade => 4096,
             WorkoutCapabilities::Resistance => 8192,
             WorkoutCapabilities::Protected => 16384,
-            WorkoutCapabilities::UnknownVariant(value) => value,
+            WorkoutCapabilities::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -10144,7 +10213,7 @@ impl fmt::Display for WorkoutCapabilities {
             WorkoutCapabilities::Grade => write!(f, "grade"),
             WorkoutCapabilities::Resistance => write!(f, "resistance"),
             WorkoutCapabilities::Protected => write!(f, "protected"),
-            WorkoutCapabilities::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            WorkoutCapabilities::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -10165,7 +10234,7 @@ impl convert::From<u32> for WorkoutCapabilities {
             4096 => WorkoutCapabilities::Grade,
             8192 => WorkoutCapabilities::Resistance,
             16384 => WorkoutCapabilities::Protected,
-            _ => WorkoutCapabilities::UnknownVariant(value),
+            _ => WorkoutCapabilities::Value(value),
         }
     }
 }
@@ -10179,7 +10248,10 @@ impl Serialize for WorkoutCapabilities {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            WorkoutCapabilities::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -10191,7 +10263,7 @@ pub enum BatteryStatus {
     Critical,
     Charging,
     Unknown,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl BatteryStatus {
     pub fn is_named_variant(value: i64) -> bool {
@@ -10215,7 +10287,7 @@ impl BatteryStatus {
             BatteryStatus::Critical => 5,
             BatteryStatus::Charging => 6,
             BatteryStatus::Unknown => 7,
-            BatteryStatus::UnknownVariant(value) => value,
+            BatteryStatus::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -10232,7 +10304,7 @@ impl fmt::Display for BatteryStatus {
             BatteryStatus::Critical => write!(f, "critical"),
             BatteryStatus::Charging => write!(f, "charging"),
             BatteryStatus::Unknown => write!(f, "unknown"),
-            BatteryStatus::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            BatteryStatus::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -10246,7 +10318,7 @@ impl convert::From<u8> for BatteryStatus {
             5 => BatteryStatus::Critical,
             6 => BatteryStatus::Charging,
             7 => BatteryStatus::Unknown,
-            _ => BatteryStatus::UnknownVariant(value),
+            _ => BatteryStatus::Value(value),
         }
     }
 }
@@ -10260,7 +10332,10 @@ impl Serialize for BatteryStatus {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            BatteryStatus::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -10332,7 +10407,7 @@ pub enum CourseCapabilities {
     Training,
     Navigation,
     Bikeway,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl CourseCapabilities {
     pub fn is_named_variant(value: i64) -> bool {
@@ -10364,7 +10439,7 @@ impl CourseCapabilities {
             CourseCapabilities::Training => 256,
             CourseCapabilities::Navigation => 512,
             CourseCapabilities::Bikeway => 1024,
-            CourseCapabilities::UnknownVariant(value) => value,
+            CourseCapabilities::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -10385,7 +10460,7 @@ impl fmt::Display for CourseCapabilities {
             CourseCapabilities::Training => write!(f, "training"),
             CourseCapabilities::Navigation => write!(f, "navigation"),
             CourseCapabilities::Bikeway => write!(f, "bikeway"),
-            CourseCapabilities::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CourseCapabilities::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -10403,7 +10478,7 @@ impl convert::From<u32> for CourseCapabilities {
             256 => CourseCapabilities::Training,
             512 => CourseCapabilities::Navigation,
             1024 => CourseCapabilities::Bikeway,
-            _ => CourseCapabilities::UnknownVariant(value),
+            _ => CourseCapabilities::Value(value),
         }
     }
 }
@@ -10417,13 +10492,16 @@ impl Serialize for CourseCapabilities {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CourseCapabilities::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum Weight {
     Calculating,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl Weight {
     pub fn is_named_variant(value: i64) -> bool {
@@ -10435,7 +10513,7 @@ impl Weight {
     pub fn as_u16(self) -> u16 {
         match self {
             Weight::Calculating => 65534,
-            Weight::UnknownVariant(value) => value,
+            Weight::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -10446,7 +10524,7 @@ impl fmt::Display for Weight {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             Weight::Calculating => write!(f, "calculating"),
-            Weight::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            Weight::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -10454,7 +10532,7 @@ impl convert::From<u16> for Weight {
     fn from(value: u16) -> Self {
         match value {
             65534 => Weight::Calculating,
-            _ => Weight::UnknownVariant(value),
+            _ => Weight::Value(value),
         }
     }
 }
@@ -10468,14 +10546,17 @@ impl Serialize for Weight {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            Weight::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// 0 - 100 indicates% of max hr; >100 indicates bpm (255 max) plus 100
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum WorkoutHr {
     BpmOffset,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl WorkoutHr {
     pub fn is_named_variant(value: i64) -> bool {
@@ -10487,7 +10568,7 @@ impl WorkoutHr {
     pub fn as_u32(self) -> u32 {
         match self {
             WorkoutHr::BpmOffset => 100,
-            WorkoutHr::UnknownVariant(value) => value,
+            WorkoutHr::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -10498,7 +10579,7 @@ impl fmt::Display for WorkoutHr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             WorkoutHr::BpmOffset => write!(f, "bpm_offset"),
-            WorkoutHr::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            WorkoutHr::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -10506,7 +10587,7 @@ impl convert::From<u32> for WorkoutHr {
     fn from(value: u32) -> Self {
         match value {
             100 => WorkoutHr::BpmOffset,
-            _ => WorkoutHr::UnknownVariant(value),
+            _ => WorkoutHr::Value(value),
         }
     }
 }
@@ -10520,14 +10601,17 @@ impl Serialize for WorkoutHr {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            WorkoutHr::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 /// 0 - 1000 indicates % of functional threshold power; >1000 indicates watts plus 1000.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum WorkoutPower {
     WattsOffset,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl WorkoutPower {
     pub fn is_named_variant(value: i64) -> bool {
@@ -10539,7 +10623,7 @@ impl WorkoutPower {
     pub fn as_u32(self) -> u32 {
         match self {
             WorkoutPower::WattsOffset => 1000,
-            WorkoutPower::UnknownVariant(value) => value,
+            WorkoutPower::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -10550,7 +10634,7 @@ impl fmt::Display for WorkoutPower {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             WorkoutPower::WattsOffset => write!(f, "watts_offset"),
-            WorkoutPower::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            WorkoutPower::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -10558,7 +10642,7 @@ impl convert::From<u32> for WorkoutPower {
     fn from(value: u32) -> Self {
         match value {
             1000 => WorkoutPower::WattsOffset,
-            _ => WorkoutPower::UnknownVariant(value),
+            _ => WorkoutPower::Value(value),
         }
     }
 }
@@ -10572,7 +10656,10 @@ impl Serialize for WorkoutPower {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            WorkoutPower::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -10654,7 +10741,7 @@ pub enum UserLocalId {
     StationaryMax,
     PortableMin,
     PortableMax,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl UserLocalId {
     pub fn is_named_variant(value: i64) -> bool {
@@ -10676,7 +10763,7 @@ impl UserLocalId {
             UserLocalId::StationaryMax => 255,
             UserLocalId::PortableMin => 256,
             UserLocalId::PortableMax => 65534,
-            UserLocalId::UnknownVariant(value) => value,
+            UserLocalId::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -10692,7 +10779,7 @@ impl fmt::Display for UserLocalId {
             UserLocalId::StationaryMax => write!(f, "stationary_max"),
             UserLocalId::PortableMin => write!(f, "portable_min"),
             UserLocalId::PortableMax => write!(f, "portable_max"),
-            UserLocalId::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            UserLocalId::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -10705,7 +10792,7 @@ impl convert::From<u16> for UserLocalId {
             255 => UserLocalId::StationaryMax,
             256 => UserLocalId::PortableMin,
             65534 => UserLocalId::PortableMax,
-            _ => UserLocalId::UnknownVariant(value),
+            _ => UserLocalId::Value(value),
         }
     }
 }
@@ -10719,7 +10806,10 @@ impl Serialize for UserLocalId {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            UserLocalId::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -11184,7 +11274,7 @@ pub enum LeftRightBalance {
     Mask,
     /// data corresponds to right if set, otherwise unknown
     Right,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl LeftRightBalance {
     pub fn is_named_variant(value: i64) -> bool {
@@ -11198,7 +11288,7 @@ impl LeftRightBalance {
         match self {
             LeftRightBalance::Mask => 127,
             LeftRightBalance::Right => 128,
-            LeftRightBalance::UnknownVariant(value) => value,
+            LeftRightBalance::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -11210,7 +11300,7 @@ impl fmt::Display for LeftRightBalance {
         match &self {
             LeftRightBalance::Mask => write!(f, "mask"),
             LeftRightBalance::Right => write!(f, "right"),
-            LeftRightBalance::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LeftRightBalance::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -11219,7 +11309,7 @@ impl convert::From<u8> for LeftRightBalance {
         match value {
             127 => LeftRightBalance::Mask,
             128 => LeftRightBalance::Right,
-            _ => LeftRightBalance::UnknownVariant(value),
+            _ => LeftRightBalance::Value(value),
         }
     }
 }
@@ -11233,7 +11323,10 @@ impl Serialize for LeftRightBalance {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LeftRightBalance::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -11242,7 +11335,7 @@ pub enum LeftRightBalance100 {
     Mask,
     /// data corresponds to right if set, otherwise unknown
     Right,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl LeftRightBalance100 {
     pub fn is_named_variant(value: i64) -> bool {
@@ -11256,7 +11349,7 @@ impl LeftRightBalance100 {
         match self {
             LeftRightBalance100::Mask => 16383,
             LeftRightBalance100::Right => 32768,
-            LeftRightBalance100::UnknownVariant(value) => value,
+            LeftRightBalance100::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -11268,7 +11361,7 @@ impl fmt::Display for LeftRightBalance100 {
         match &self {
             LeftRightBalance100::Mask => write!(f, "mask"),
             LeftRightBalance100::Right => write!(f, "right"),
-            LeftRightBalance100::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LeftRightBalance100::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -11277,7 +11370,7 @@ impl convert::From<u16> for LeftRightBalance100 {
         match value {
             16383 => LeftRightBalance100::Mask,
             32768 => LeftRightBalance100::Right,
-            _ => LeftRightBalance100::UnknownVariant(value),
+            _ => LeftRightBalance100::Value(value),
         }
     }
 }
@@ -11291,7 +11384,10 @@ impl Serialize for LeftRightBalance100 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LeftRightBalance100::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -11476,7 +11572,7 @@ pub enum ConnectivityCapabilities {
     LiveTrackMessaging,
     /// Device supports instant input feature
     InstantInput,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl ConnectivityCapabilities {
     pub fn is_named_variant(value: i64) -> bool {
@@ -11550,7 +11646,7 @@ impl ConnectivityCapabilities {
             ConnectivityCapabilities::LiveTrackAutoStart => 536870912,
             ConnectivityCapabilities::LiveTrackMessaging => 1073741824,
             ConnectivityCapabilities::InstantInput => 2147483648,
-            ConnectivityCapabilities::UnknownVariant(value) => value,
+            ConnectivityCapabilities::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -11604,9 +11700,7 @@ impl fmt::Display for ConnectivityCapabilities {
             ConnectivityCapabilities::LiveTrackAutoStart => write!(f, "live_track_auto_start"),
             ConnectivityCapabilities::LiveTrackMessaging => write!(f, "live_track_messaging"),
             ConnectivityCapabilities::InstantInput => write!(f, "instant_input"),
-            ConnectivityCapabilities::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            ConnectivityCapabilities::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -11645,7 +11739,7 @@ impl convert::From<u32> for ConnectivityCapabilities {
             536870912 => ConnectivityCapabilities::LiveTrackAutoStart,
             1073741824 => ConnectivityCapabilities::LiveTrackMessaging,
             2147483648 => ConnectivityCapabilities::InstantInput,
-            _ => ConnectivityCapabilities::UnknownVariant(value),
+            _ => ConnectivityCapabilities::Value(value),
         }
     }
 }
@@ -11659,7 +11753,10 @@ impl Serialize for ConnectivityCapabilities {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            ConnectivityCapabilities::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -13838,7 +13935,7 @@ pub enum CommTimeoutType {
     ConnectionLost,
     /// Connection closed due to extended bad communications
     ConnectionTimeout,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl CommTimeoutType {
     pub fn is_named_variant(value: i64) -> bool {
@@ -13856,7 +13953,7 @@ impl CommTimeoutType {
             CommTimeoutType::PairingTimeout => 1,
             CommTimeoutType::ConnectionLost => 2,
             CommTimeoutType::ConnectionTimeout => 3,
-            CommTimeoutType::UnknownVariant(value) => value,
+            CommTimeoutType::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -13870,7 +13967,7 @@ impl fmt::Display for CommTimeoutType {
             CommTimeoutType::PairingTimeout => write!(f, "pairing_timeout"),
             CommTimeoutType::ConnectionLost => write!(f, "connection_lost"),
             CommTimeoutType::ConnectionTimeout => write!(f, "connection_timeout"),
-            CommTimeoutType::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CommTimeoutType::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -13881,7 +13978,7 @@ impl convert::From<u16> for CommTimeoutType {
             1 => CommTimeoutType::PairingTimeout,
             2 => CommTimeoutType::ConnectionLost,
             3 => CommTimeoutType::ConnectionTimeout,
-            _ => CommTimeoutType::UnknownVariant(value),
+            _ => CommTimeoutType::Value(value),
         }
     }
 }
@@ -13895,7 +13992,10 @@ impl Serialize for CommTimeoutType {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CommTimeoutType::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -14045,7 +14145,7 @@ pub enum AttitudeValidity {
     SolutionCoasting,
     TrueTrackAngle,
     MagneticHeading,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl AttitudeValidity {
     pub fn is_named_variant(value: i64) -> bool {
@@ -14081,7 +14181,7 @@ impl AttitudeValidity {
             AttitudeValidity::SolutionCoasting => 1024,
             AttitudeValidity::TrueTrackAngle => 2048,
             AttitudeValidity::MagneticHeading => 4096,
-            AttitudeValidity::UnknownVariant(value) => value,
+            AttitudeValidity::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -14104,7 +14204,7 @@ impl fmt::Display for AttitudeValidity {
             AttitudeValidity::SolutionCoasting => write!(f, "solution_coasting"),
             AttitudeValidity::TrueTrackAngle => write!(f, "true_track_angle"),
             AttitudeValidity::MagneticHeading => write!(f, "magnetic_heading"),
-            AttitudeValidity::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            AttitudeValidity::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -14124,7 +14224,7 @@ impl convert::From<u16> for AttitudeValidity {
             1024 => AttitudeValidity::SolutionCoasting,
             2048 => AttitudeValidity::TrueTrackAngle,
             4096 => AttitudeValidity::MagneticHeading,
-            _ => AttitudeValidity::UnknownVariant(value),
+            _ => AttitudeValidity::Value(value),
         }
     }
 }
@@ -14138,7 +14238,10 @@ impl Serialize for AttitudeValidity {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            AttitudeValidity::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -15522,7 +15625,7 @@ pub enum AutoActivityDetect {
     Walking,
     Elliptical,
     Sedentary,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl AutoActivityDetect {
     pub fn is_named_variant(value: i64) -> bool {
@@ -15546,7 +15649,7 @@ impl AutoActivityDetect {
             AutoActivityDetect::Walking => 8,
             AutoActivityDetect::Elliptical => 32,
             AutoActivityDetect::Sedentary => 1024,
-            AutoActivityDetect::UnknownVariant(value) => value,
+            AutoActivityDetect::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -15563,7 +15666,7 @@ impl fmt::Display for AutoActivityDetect {
             AutoActivityDetect::Walking => write!(f, "walking"),
             AutoActivityDetect::Elliptical => write!(f, "elliptical"),
             AutoActivityDetect::Sedentary => write!(f, "sedentary"),
-            AutoActivityDetect::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            AutoActivityDetect::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -15577,7 +15680,7 @@ impl convert::From<u32> for AutoActivityDetect {
             8 => AutoActivityDetect::Walking,
             32 => AutoActivityDetect::Elliptical,
             1024 => AutoActivityDetect::Sedentary,
-            _ => AutoActivityDetect::UnknownVariant(value),
+            _ => AutoActivityDetect::Value(value),
         }
     }
 }
@@ -15591,7 +15694,10 @@ impl Serialize for AutoActivityDetect {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            AutoActivityDetect::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -15604,7 +15710,7 @@ pub enum SupportedExdScreenLayouts {
     FullQuarterSplit,
     HalfVerticalLeftSplit,
     HalfHorizontalTopSplit,
-    UnknownVariant(u32),
+    Value(u32),
 }
 impl SupportedExdScreenLayouts {
     pub fn is_named_variant(value: i64) -> bool {
@@ -15630,7 +15736,7 @@ impl SupportedExdScreenLayouts {
             SupportedExdScreenLayouts::FullQuarterSplit => 32,
             SupportedExdScreenLayouts::HalfVerticalLeftSplit => 64,
             SupportedExdScreenLayouts::HalfHorizontalTopSplit => 128,
-            SupportedExdScreenLayouts::UnknownVariant(value) => value,
+            SupportedExdScreenLayouts::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -15656,9 +15762,7 @@ impl fmt::Display for SupportedExdScreenLayouts {
             SupportedExdScreenLayouts::HalfHorizontalTopSplit => {
                 write!(f, "half_horizontal_top_split")
             }
-            SupportedExdScreenLayouts::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            SupportedExdScreenLayouts::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -15673,7 +15777,7 @@ impl convert::From<u32> for SupportedExdScreenLayouts {
             32 => SupportedExdScreenLayouts::FullQuarterSplit,
             64 => SupportedExdScreenLayouts::HalfVerticalLeftSplit,
             128 => SupportedExdScreenLayouts::HalfHorizontalTopSplit,
-            _ => SupportedExdScreenLayouts::UnknownVariant(value),
+            _ => SupportedExdScreenLayouts::Value(value),
         }
     }
 }
@@ -15687,7 +15791,10 @@ impl Serialize for SupportedExdScreenLayouts {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SupportedExdScreenLayouts::Value(value) => serializer.serialize_u32(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -15709,7 +15816,7 @@ pub enum FitBaseType {
     Sint64,
     Uint64,
     Uint64z,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl FitBaseType {
     pub fn is_named_variant(value: i64) -> bool {
@@ -15753,7 +15860,7 @@ impl FitBaseType {
             FitBaseType::Sint64 => 142,
             FitBaseType::Uint64 => 143,
             FitBaseType::Uint64z => 144,
-            FitBaseType::UnknownVariant(value) => value,
+            FitBaseType::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -15780,7 +15887,7 @@ impl fmt::Display for FitBaseType {
             FitBaseType::Sint64 => write!(f, "sint64"),
             FitBaseType::Uint64 => write!(f, "uint64"),
             FitBaseType::Uint64z => write!(f, "uint64z"),
-            FitBaseType::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            FitBaseType::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -15804,7 +15911,7 @@ impl convert::From<u8> for FitBaseType {
             142 => FitBaseType::Sint64,
             143 => FitBaseType::Uint64,
             144 => FitBaseType::Uint64z,
-            _ => FitBaseType::UnknownVariant(value),
+            _ => FitBaseType::Value(value),
         }
     }
 }
@@ -15818,7 +15925,10 @@ impl Serialize for FitBaseType {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            FitBaseType::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -16061,7 +16171,7 @@ impl Serialize for TurnType {
 pub enum BikeLightBeamAngleMode {
     Manual,
     Auto,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl BikeLightBeamAngleMode {
     pub fn is_named_variant(value: i64) -> bool {
@@ -16075,7 +16185,7 @@ impl BikeLightBeamAngleMode {
         match self {
             BikeLightBeamAngleMode::Manual => 0,
             BikeLightBeamAngleMode::Auto => 1,
-            BikeLightBeamAngleMode::UnknownVariant(value) => value,
+            BikeLightBeamAngleMode::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -16087,9 +16197,7 @@ impl fmt::Display for BikeLightBeamAngleMode {
         match &self {
             BikeLightBeamAngleMode::Manual => write!(f, "manual"),
             BikeLightBeamAngleMode::Auto => write!(f, "auto"),
-            BikeLightBeamAngleMode::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            BikeLightBeamAngleMode::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -16098,7 +16206,7 @@ impl convert::From<u8> for BikeLightBeamAngleMode {
         match value {
             0 => BikeLightBeamAngleMode::Manual,
             1 => BikeLightBeamAngleMode::Auto,
-            _ => BikeLightBeamAngleMode::UnknownVariant(value),
+            _ => BikeLightBeamAngleMode::Value(value),
         }
     }
 }
@@ -16112,7 +16220,10 @@ impl Serialize for BikeLightBeamAngleMode {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            BikeLightBeamAngleMode::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -16120,7 +16231,7 @@ pub enum FitBaseUnit {
     Other,
     Kilogram,
     Pound,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl FitBaseUnit {
     pub fn is_named_variant(value: i64) -> bool {
@@ -16136,7 +16247,7 @@ impl FitBaseUnit {
             FitBaseUnit::Other => 0,
             FitBaseUnit::Kilogram => 1,
             FitBaseUnit::Pound => 2,
-            FitBaseUnit::UnknownVariant(value) => value,
+            FitBaseUnit::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -16149,7 +16260,7 @@ impl fmt::Display for FitBaseUnit {
             FitBaseUnit::Other => write!(f, "other"),
             FitBaseUnit::Kilogram => write!(f, "kilogram"),
             FitBaseUnit::Pound => write!(f, "pound"),
-            FitBaseUnit::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            FitBaseUnit::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -16159,7 +16270,7 @@ impl convert::From<u16> for FitBaseUnit {
             0 => FitBaseUnit::Other,
             1 => FitBaseUnit::Kilogram,
             2 => FitBaseUnit::Pound,
-            _ => FitBaseUnit::UnknownVariant(value),
+            _ => FitBaseUnit::Value(value),
         }
     }
 }
@@ -16173,14 +16284,17 @@ impl Serialize for FitBaseUnit {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            FitBaseUnit::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SetType {
     Rest,
     Active,
-    UnknownVariant(u8),
+    Value(u8),
 }
 impl SetType {
     pub fn is_named_variant(value: i64) -> bool {
@@ -16194,7 +16308,7 @@ impl SetType {
         match self {
             SetType::Rest => 0,
             SetType::Active => 1,
-            SetType::UnknownVariant(value) => value,
+            SetType::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -16206,7 +16320,7 @@ impl fmt::Display for SetType {
         match &self {
             SetType::Rest => write!(f, "rest"),
             SetType::Active => write!(f, "active"),
-            SetType::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SetType::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -16215,7 +16329,7 @@ impl convert::From<u8> for SetType {
         match value {
             0 => SetType::Rest,
             1 => SetType::Active,
-            _ => SetType::UnknownVariant(value),
+            _ => SetType::Value(value),
         }
     }
 }
@@ -16229,7 +16343,10 @@ impl Serialize for SetType {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SetType::Value(value) => serializer.serialize_u8(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -16268,7 +16385,7 @@ pub enum ExerciseCategory {
     WarmUp,
     Run,
     Unknown,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl ExerciseCategory {
     pub fn is_named_variant(value: i64) -> bool {
@@ -16346,7 +16463,7 @@ impl ExerciseCategory {
             ExerciseCategory::WarmUp => 31,
             ExerciseCategory::Run => 32,
             ExerciseCategory::Unknown => 65534,
-            ExerciseCategory::UnknownVariant(value) => value,
+            ExerciseCategory::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -16390,7 +16507,7 @@ impl fmt::Display for ExerciseCategory {
             ExerciseCategory::WarmUp => write!(f, "warm_up"),
             ExerciseCategory::Run => write!(f, "run"),
             ExerciseCategory::Unknown => write!(f, "unknown"),
-            ExerciseCategory::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            ExerciseCategory::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -16431,7 +16548,7 @@ impl convert::From<u16> for ExerciseCategory {
             31 => ExerciseCategory::WarmUp,
             32 => ExerciseCategory::Run,
             65534 => ExerciseCategory::Unknown,
-            _ => ExerciseCategory::UnknownVariant(value),
+            _ => ExerciseCategory::Value(value),
         }
     }
 }
@@ -16445,7 +16562,10 @@ impl Serialize for ExerciseCategory {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            ExerciseCategory::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -16477,7 +16597,7 @@ pub enum BenchPressExerciseName {
     TripleStopBarbellBenchPress,
     WideGripBarbellBenchPress,
     AlternatingDumbbellChestPress,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl BenchPressExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -16541,7 +16661,7 @@ impl BenchPressExerciseName {
             BenchPressExerciseName::TripleStopBarbellBenchPress => 24,
             BenchPressExerciseName::WideGripBarbellBenchPress => 25,
             BenchPressExerciseName::AlternatingDumbbellChestPress => 26,
-            BenchPressExerciseName::UnknownVariant(value) => value,
+            BenchPressExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -16618,9 +16738,7 @@ impl fmt::Display for BenchPressExerciseName {
             BenchPressExerciseName::AlternatingDumbbellChestPress => {
                 write!(f, "alternating_dumbbell_chest_press")
             }
-            BenchPressExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            BenchPressExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -16654,7 +16772,7 @@ impl convert::From<u16> for BenchPressExerciseName {
             24 => BenchPressExerciseName::TripleStopBarbellBenchPress,
             25 => BenchPressExerciseName::WideGripBarbellBenchPress,
             26 => BenchPressExerciseName::AlternatingDumbbellChestPress,
-            _ => BenchPressExerciseName::UnknownVariant(value),
+            _ => BenchPressExerciseName::Value(value),
         }
     }
 }
@@ -16668,7 +16786,10 @@ impl Serialize for BenchPressExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            BenchPressExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -16694,7 +16815,7 @@ pub enum CalfRaiseExerciseName {
     StandingCalfRaise,
     WeightedStandingCalfRaise,
     StandingDumbbellCalfRaise,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl CalfRaiseExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -16746,7 +16867,7 @@ impl CalfRaiseExerciseName {
             CalfRaiseExerciseName::StandingCalfRaise => 18,
             CalfRaiseExerciseName::WeightedStandingCalfRaise => 19,
             CalfRaiseExerciseName::StandingDumbbellCalfRaise => 20,
-            CalfRaiseExerciseName::UnknownVariant(value) => value,
+            CalfRaiseExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -16809,7 +16930,7 @@ impl fmt::Display for CalfRaiseExerciseName {
             CalfRaiseExerciseName::StandingDumbbellCalfRaise => {
                 write!(f, "standing_dumbbell_calf_raise")
             }
-            CalfRaiseExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CalfRaiseExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -16837,7 +16958,7 @@ impl convert::From<u16> for CalfRaiseExerciseName {
             18 => CalfRaiseExerciseName::StandingCalfRaise,
             19 => CalfRaiseExerciseName::WeightedStandingCalfRaise,
             20 => CalfRaiseExerciseName::StandingDumbbellCalfRaise,
-            _ => CalfRaiseExerciseName::UnknownVariant(value),
+            _ => CalfRaiseExerciseName::Value(value),
         }
     }
 }
@@ -16851,7 +16972,10 @@ impl Serialize for CalfRaiseExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CalfRaiseExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -16878,7 +17002,7 @@ pub enum CardioExerciseName {
     WeightedSquatJacks,
     TripleUnder,
     WeightedTripleUnder,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl CardioExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -16932,7 +17056,7 @@ impl CardioExerciseName {
             CardioExerciseName::WeightedSquatJacks => 19,
             CardioExerciseName::TripleUnder => 20,
             CardioExerciseName::WeightedTripleUnder => 21,
-            CardioExerciseName::UnknownVariant(value) => value,
+            CardioExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -16968,7 +17092,7 @@ impl fmt::Display for CardioExerciseName {
             CardioExerciseName::WeightedSquatJacks => write!(f, "weighted_squat_jacks"),
             CardioExerciseName::TripleUnder => write!(f, "triple_under"),
             CardioExerciseName::WeightedTripleUnder => write!(f, "weighted_triple_under"),
-            CardioExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CardioExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -16997,7 +17121,7 @@ impl convert::From<u16> for CardioExerciseName {
             19 => CardioExerciseName::WeightedSquatJacks,
             20 => CardioExerciseName::TripleUnder,
             21 => CardioExerciseName::WeightedTripleUnder,
-            _ => CardioExerciseName::UnknownVariant(value),
+            _ => CardioExerciseName::Value(value),
         }
     }
 }
@@ -17011,7 +17135,10 @@ impl Serialize for CardioExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CardioExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -17021,7 +17148,7 @@ pub enum CarryExerciseName {
     FarmersWalkOnToes,
     HexDumbbellHold,
     OverheadCarry,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl CarryExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -17041,7 +17168,7 @@ impl CarryExerciseName {
             CarryExerciseName::FarmersWalkOnToes => 2,
             CarryExerciseName::HexDumbbellHold => 3,
             CarryExerciseName::OverheadCarry => 4,
-            CarryExerciseName::UnknownVariant(value) => value,
+            CarryExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -17056,7 +17183,7 @@ impl fmt::Display for CarryExerciseName {
             CarryExerciseName::FarmersWalkOnToes => write!(f, "farmers_walk_on_toes"),
             CarryExerciseName::HexDumbbellHold => write!(f, "hex_dumbbell_hold"),
             CarryExerciseName::OverheadCarry => write!(f, "overhead_carry"),
-            CarryExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CarryExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -17068,7 +17195,7 @@ impl convert::From<u16> for CarryExerciseName {
             2 => CarryExerciseName::FarmersWalkOnToes,
             3 => CarryExerciseName::HexDumbbellHold,
             4 => CarryExerciseName::OverheadCarry,
-            _ => CarryExerciseName::UnknownVariant(value),
+            _ => CarryExerciseName::Value(value),
         }
     }
 }
@@ -17082,7 +17209,10 @@ impl Serialize for CarryExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CarryExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -17110,7 +17240,7 @@ pub enum ChopExerciseName {
     StandingSplitRotationalChop,
     StandingSplitRotationalReverseChop,
     StandingStabilityReverseChop,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl ChopExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -17166,7 +17296,7 @@ impl ChopExerciseName {
             ChopExerciseName::StandingSplitRotationalChop => 20,
             ChopExerciseName::StandingSplitRotationalReverseChop => 21,
             ChopExerciseName::StandingStabilityReverseChop => 22,
-            ChopExerciseName::UnknownVariant(value) => value,
+            ChopExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -17217,7 +17347,7 @@ impl fmt::Display for ChopExerciseName {
             ChopExerciseName::StandingStabilityReverseChop => {
                 write!(f, "standing_stability_reverse_chop")
             }
-            ChopExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            ChopExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -17247,7 +17377,7 @@ impl convert::From<u16> for ChopExerciseName {
             20 => ChopExerciseName::StandingSplitRotationalChop,
             21 => ChopExerciseName::StandingSplitRotationalReverseChop,
             22 => ChopExerciseName::StandingStabilityReverseChop,
-            _ => ChopExerciseName::UnknownVariant(value),
+            _ => ChopExerciseName::Value(value),
         }
     }
 }
@@ -17261,7 +17391,10 @@ impl Serialize for ChopExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            ChopExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -17342,7 +17475,7 @@ pub enum CoreExerciseName {
     Swimming,
     Teaser,
     TheHundred,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl CoreExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -17498,7 +17631,7 @@ impl CoreExerciseName {
             CoreExerciseName::Swimming => 70,
             CoreExerciseName::Teaser => 71,
             CoreExerciseName::TheHundred => 72,
-            CoreExerciseName::UnknownVariant(value) => value,
+            CoreExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -17599,7 +17732,7 @@ impl fmt::Display for CoreExerciseName {
             CoreExerciseName::Swimming => write!(f, "swimming"),
             CoreExerciseName::Teaser => write!(f, "teaser"),
             CoreExerciseName::TheHundred => write!(f, "the_hundred"),
-            CoreExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CoreExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -17679,7 +17812,7 @@ impl convert::From<u16> for CoreExerciseName {
             70 => CoreExerciseName::Swimming,
             71 => CoreExerciseName::Teaser,
             72 => CoreExerciseName::TheHundred,
-            _ => CoreExerciseName::UnknownVariant(value),
+            _ => CoreExerciseName::Value(value),
         }
     }
 }
@@ -17693,7 +17826,10 @@ impl Serialize for CoreExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CoreExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -17783,7 +17919,7 @@ pub enum CrunchExerciseName {
     WeightedToesToBar,
     Crunch,
     StraightLegCrunchWithBall,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl CrunchExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -17963,7 +18099,7 @@ impl CrunchExerciseName {
             CrunchExerciseName::WeightedToesToBar => 82,
             CrunchExerciseName::Crunch => 83,
             CrunchExerciseName::StraightLegCrunchWithBall => 84,
-            CrunchExerciseName::UnknownVariant(value) => value,
+            CrunchExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -18118,7 +18254,7 @@ impl fmt::Display for CrunchExerciseName {
             CrunchExerciseName::StraightLegCrunchWithBall => {
                 write!(f, "straight_leg_crunch_with_ball")
             }
-            CrunchExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CrunchExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -18210,7 +18346,7 @@ impl convert::From<u16> for CrunchExerciseName {
             82 => CrunchExerciseName::WeightedToesToBar,
             83 => CrunchExerciseName::Crunch,
             84 => CrunchExerciseName::StraightLegCrunchWithBall,
-            _ => CrunchExerciseName::UnknownVariant(value),
+            _ => CrunchExerciseName::Value(value),
         }
     }
 }
@@ -18224,7 +18360,10 @@ impl Serialize for CrunchExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CrunchExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -18273,7 +18412,7 @@ pub enum CurlExerciseName {
     SwissBallEzBarPreacherCurl,
     TwistingStandingDumbbellBicepsCurl,
     WideGripEzBarBicepsCurl,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl CurlExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -18371,7 +18510,7 @@ impl CurlExerciseName {
             CurlExerciseName::SwissBallEzBarPreacherCurl => 41,
             CurlExerciseName::TwistingStandingDumbbellBicepsCurl => 42,
             CurlExerciseName::WideGripEzBarBicepsCurl => 43,
-            CurlExerciseName::UnknownVariant(value) => value,
+            CurlExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -18467,7 +18606,7 @@ impl fmt::Display for CurlExerciseName {
                 write!(f, "twisting_standing_dumbbell_biceps_curl")
             }
             CurlExerciseName::WideGripEzBarBicepsCurl => write!(f, "wide_grip_ez_bar_biceps_curl"),
-            CurlExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            CurlExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -18518,7 +18657,7 @@ impl convert::From<u16> for CurlExerciseName {
             41 => CurlExerciseName::SwissBallEzBarPreacherCurl,
             42 => CurlExerciseName::TwistingStandingDumbbellBicepsCurl,
             43 => CurlExerciseName::WideGripEzBarBicepsCurl,
-            _ => CurlExerciseName::UnknownVariant(value),
+            _ => CurlExerciseName::Value(value),
         }
     }
 }
@@ -18532,7 +18671,10 @@ impl Serialize for CurlExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            CurlExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -18556,7 +18698,7 @@ pub enum DeadliftExerciseName {
     SumoDeadliftHighPull,
     TrapBarDeadlift,
     WideGripBarbellDeadlift,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl DeadliftExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -18604,7 +18746,7 @@ impl DeadliftExerciseName {
             DeadliftExerciseName::SumoDeadliftHighPull => 16,
             DeadliftExerciseName::TrapBarDeadlift => 17,
             DeadliftExerciseName::WideGripBarbellDeadlift => 18,
-            DeadliftExerciseName::UnknownVariant(value) => value,
+            DeadliftExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -18651,7 +18793,7 @@ impl fmt::Display for DeadliftExerciseName {
             DeadliftExerciseName::WideGripBarbellDeadlift => {
                 write!(f, "wide_grip_barbell_deadlift")
             }
-            DeadliftExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            DeadliftExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -18677,7 +18819,7 @@ impl convert::From<u16> for DeadliftExerciseName {
             16 => DeadliftExerciseName::SumoDeadliftHighPull,
             17 => DeadliftExerciseName::TrapBarDeadlift,
             18 => DeadliftExerciseName::WideGripBarbellDeadlift,
-            _ => DeadliftExerciseName::UnknownVariant(value),
+            _ => DeadliftExerciseName::Value(value),
         }
     }
 }
@@ -18691,7 +18833,10 @@ impl Serialize for DeadliftExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            DeadliftExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -18706,7 +18851,7 @@ pub enum FlyeExerciseName {
     SwissBallDumbbellFlye,
     ArmRotations,
     HugATree,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl FlyeExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -18736,7 +18881,7 @@ impl FlyeExerciseName {
             FlyeExerciseName::SwissBallDumbbellFlye => 7,
             FlyeExerciseName::ArmRotations => 8,
             FlyeExerciseName::HugATree => 9,
-            FlyeExerciseName::UnknownVariant(value) => value,
+            FlyeExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -18758,7 +18903,7 @@ impl fmt::Display for FlyeExerciseName {
             FlyeExerciseName::SwissBallDumbbellFlye => write!(f, "swiss_ball_dumbbell_flye"),
             FlyeExerciseName::ArmRotations => write!(f, "arm_rotations"),
             FlyeExerciseName::HugATree => write!(f, "hug_a_tree"),
-            FlyeExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            FlyeExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -18775,7 +18920,7 @@ impl convert::From<u16> for FlyeExerciseName {
             7 => FlyeExerciseName::SwissBallDumbbellFlye,
             8 => FlyeExerciseName::ArmRotations,
             9 => FlyeExerciseName::HugATree,
-            _ => FlyeExerciseName::UnknownVariant(value),
+            _ => FlyeExerciseName::Value(value),
         }
     }
 }
@@ -18789,7 +18934,10 @@ impl Serialize for FlyeExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            FlyeExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -18846,7 +18994,7 @@ pub enum HipRaiseExerciseName {
     LegCircles,
     LegLift,
     LegLiftInExternalRotation,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl HipRaiseExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -18956,7 +19104,7 @@ impl HipRaiseExerciseName {
             HipRaiseExerciseName::LegCircles => 47,
             HipRaiseExerciseName::LegLift => 48,
             HipRaiseExerciseName::LegLiftInExternalRotation => 49,
-            HipRaiseExerciseName::UnknownVariant(value) => value,
+            HipRaiseExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -19085,7 +19233,7 @@ impl fmt::Display for HipRaiseExerciseName {
             HipRaiseExerciseName::LegLiftInExternalRotation => {
                 write!(f, "leg_lift_in_external_rotation")
             }
-            HipRaiseExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            HipRaiseExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -19142,7 +19290,7 @@ impl convert::From<u16> for HipRaiseExerciseName {
             47 => HipRaiseExerciseName::LegCircles,
             48 => HipRaiseExerciseName::LegLift,
             49 => HipRaiseExerciseName::LegLiftInExternalRotation,
-            _ => HipRaiseExerciseName::UnknownVariant(value),
+            _ => HipRaiseExerciseName::Value(value),
         }
     }
 }
@@ -19156,7 +19304,10 @@ impl Serialize for HipRaiseExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            HipRaiseExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -19195,7 +19346,7 @@ pub enum HipStabilityExerciseName {
     WeightedStandingRearLegRaise,
     SupineHipInternalRotation,
     WeightedSupineHipInternalRotation,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl HipStabilityExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -19273,7 +19424,7 @@ impl HipStabilityExerciseName {
             HipStabilityExerciseName::WeightedStandingRearLegRaise => 31,
             HipStabilityExerciseName::SupineHipInternalRotation => 32,
             HipStabilityExerciseName::WeightedSupineHipInternalRotation => 33,
-            HipStabilityExerciseName::UnknownVariant(value) => value,
+            HipStabilityExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -19353,9 +19504,7 @@ impl fmt::Display for HipStabilityExerciseName {
             HipStabilityExerciseName::WeightedSupineHipInternalRotation => {
                 write!(f, "weighted_supine_hip_internal_rotation")
             }
-            HipStabilityExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            HipStabilityExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -19396,7 +19545,7 @@ impl convert::From<u16> for HipStabilityExerciseName {
             31 => HipStabilityExerciseName::WeightedStandingRearLegRaise,
             32 => HipStabilityExerciseName::SupineHipInternalRotation,
             33 => HipStabilityExerciseName::WeightedSupineHipInternalRotation,
-            _ => HipStabilityExerciseName::UnknownVariant(value),
+            _ => HipStabilityExerciseName::Value(value),
         }
     }
 }
@@ -19410,7 +19559,10 @@ impl Serialize for HipStabilityExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            HipStabilityExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -19418,7 +19570,7 @@ pub enum HipSwingExerciseName {
     SingleArmKettlebellSwing,
     SingleArmDumbbellSwing,
     StepOutSwing,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl HipSwingExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -19434,7 +19586,7 @@ impl HipSwingExerciseName {
             HipSwingExerciseName::SingleArmKettlebellSwing => 0,
             HipSwingExerciseName::SingleArmDumbbellSwing => 1,
             HipSwingExerciseName::StepOutSwing => 2,
-            HipSwingExerciseName::UnknownVariant(value) => value,
+            HipSwingExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -19449,7 +19601,7 @@ impl fmt::Display for HipSwingExerciseName {
             }
             HipSwingExerciseName::SingleArmDumbbellSwing => write!(f, "single_arm_dumbbell_swing"),
             HipSwingExerciseName::StepOutSwing => write!(f, "step_out_swing"),
-            HipSwingExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            HipSwingExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -19459,7 +19611,7 @@ impl convert::From<u16> for HipSwingExerciseName {
             0 => HipSwingExerciseName::SingleArmKettlebellSwing,
             1 => HipSwingExerciseName::SingleArmDumbbellSwing,
             2 => HipSwingExerciseName::StepOutSwing,
-            _ => HipSwingExerciseName::UnknownVariant(value),
+            _ => HipSwingExerciseName::Value(value),
         }
     }
 }
@@ -19473,7 +19625,10 @@ impl Serialize for HipSwingExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            HipSwingExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -19519,7 +19674,7 @@ pub enum HyperextensionExerciseName {
     Cobra,
     /// Deprecated do not use
     SupineFloorBarre,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl HyperextensionExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -19609,7 +19764,7 @@ impl HyperextensionExerciseName {
             HyperextensionExerciseName::SupermanOnSwissBall => 37,
             HyperextensionExerciseName::Cobra => 38,
             HyperextensionExerciseName::SupineFloorBarre => 39,
-            HyperextensionExerciseName::UnknownVariant(value) => value,
+            HyperextensionExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -19701,9 +19856,7 @@ impl fmt::Display for HyperextensionExerciseName {
             HyperextensionExerciseName::SupermanOnSwissBall => write!(f, "superman_on_swiss_ball"),
             HyperextensionExerciseName::Cobra => write!(f, "cobra"),
             HyperextensionExerciseName::SupineFloorBarre => write!(f, "supine_floor_barre"),
-            HyperextensionExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            HyperextensionExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -19750,7 +19903,7 @@ impl convert::From<u16> for HyperextensionExerciseName {
             37 => HyperextensionExerciseName::SupermanOnSwissBall,
             38 => HyperextensionExerciseName::Cobra,
             39 => HyperextensionExerciseName::SupineFloorBarre,
-            _ => HyperextensionExerciseName::UnknownVariant(value),
+            _ => HyperextensionExerciseName::Value(value),
         }
     }
 }
@@ -19764,7 +19917,10 @@ impl Serialize for HyperextensionExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            HyperextensionExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -19803,7 +19959,7 @@ pub enum LateralRaiseExerciseName {
     WeightedWallSlide,
     ArmCircles,
     ShavingTheHead,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl LateralRaiseExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -19881,7 +20037,7 @@ impl LateralRaiseExerciseName {
             LateralRaiseExerciseName::WeightedWallSlide => 31,
             LateralRaiseExerciseName::ArmCircles => 32,
             LateralRaiseExerciseName::ShavingTheHead => 33,
-            LateralRaiseExerciseName::UnknownVariant(value) => value,
+            LateralRaiseExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -19941,9 +20097,7 @@ impl fmt::Display for LateralRaiseExerciseName {
             LateralRaiseExerciseName::WeightedWallSlide => write!(f, "weighted_wall_slide"),
             LateralRaiseExerciseName::ArmCircles => write!(f, "arm_circles"),
             LateralRaiseExerciseName::ShavingTheHead => write!(f, "shaving_the_head"),
-            LateralRaiseExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            LateralRaiseExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -19984,7 +20138,7 @@ impl convert::From<u16> for LateralRaiseExerciseName {
             31 => LateralRaiseExerciseName::WeightedWallSlide,
             32 => LateralRaiseExerciseName::ArmCircles,
             33 => LateralRaiseExerciseName::ShavingTheHead,
-            _ => LateralRaiseExerciseName::UnknownVariant(value),
+            _ => LateralRaiseExerciseName::Value(value),
         }
     }
 }
@@ -19998,7 +20152,10 @@ impl Serialize for LateralRaiseExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LateralRaiseExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -20015,7 +20172,7 @@ pub enum LegCurlExerciseName {
     StaggeredStanceGoodMorning,
     SwissBallHipRaiseAndLegCurl,
     ZercherGoodMorning,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl LegCurlExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -20049,7 +20206,7 @@ impl LegCurlExerciseName {
             LegCurlExerciseName::StaggeredStanceGoodMorning => 9,
             LegCurlExerciseName::SwissBallHipRaiseAndLegCurl => 10,
             LegCurlExerciseName::ZercherGoodMorning => 11,
-            LegCurlExerciseName::UnknownVariant(value) => value,
+            LegCurlExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -20081,7 +20238,7 @@ impl fmt::Display for LegCurlExerciseName {
                 write!(f, "swiss_ball_hip_raise_and_leg_curl")
             }
             LegCurlExerciseName::ZercherGoodMorning => write!(f, "zercher_good_morning"),
-            LegCurlExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LegCurlExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -20100,7 +20257,7 @@ impl convert::From<u16> for LegCurlExerciseName {
             9 => LegCurlExerciseName::StaggeredStanceGoodMorning,
             10 => LegCurlExerciseName::SwissBallHipRaiseAndLegCurl,
             11 => LegCurlExerciseName::ZercherGoodMorning,
-            _ => LegCurlExerciseName::UnknownVariant(value),
+            _ => LegCurlExerciseName::Value(value),
         }
     }
 }
@@ -20114,7 +20271,10 @@ impl Serialize for LegCurlExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LegCurlExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -20141,7 +20301,7 @@ pub enum LegRaiseExerciseName {
     WeightedHangingKneeRaise,
     LateralStepover,
     WeightedLateralStepover,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl LegRaiseExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -20195,7 +20355,7 @@ impl LegRaiseExerciseName {
             LegRaiseExerciseName::WeightedHangingKneeRaise => 19,
             LegRaiseExerciseName::LateralStepover => 20,
             LegRaiseExerciseName::WeightedLateralStepover => 21,
-            LegRaiseExerciseName::UnknownVariant(value) => value,
+            LegRaiseExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -20247,7 +20407,7 @@ impl fmt::Display for LegRaiseExerciseName {
             }
             LegRaiseExerciseName::LateralStepover => write!(f, "lateral_stepover"),
             LegRaiseExerciseName::WeightedLateralStepover => write!(f, "weighted_lateral_stepover"),
-            LegRaiseExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LegRaiseExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -20276,7 +20436,7 @@ impl convert::From<u16> for LegRaiseExerciseName {
             19 => LegRaiseExerciseName::WeightedHangingKneeRaise,
             20 => LegRaiseExerciseName::LateralStepover,
             21 => LegRaiseExerciseName::WeightedLateralStepover,
-            _ => LegRaiseExerciseName::UnknownVariant(value),
+            _ => LegRaiseExerciseName::Value(value),
         }
     }
 }
@@ -20290,7 +20450,10 @@ impl Serialize for LegRaiseExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LegRaiseExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -20376,7 +20539,7 @@ pub enum LungeExerciseName {
     WalkingLunge,
     WeightedWalkingLunge,
     WideGripOverheadBarbellSplitSquat,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl LungeExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -20548,7 +20711,7 @@ impl LungeExerciseName {
             LungeExerciseName::WalkingLunge => 78,
             LungeExerciseName::WeightedWalkingLunge => 79,
             LungeExerciseName::WideGripOverheadBarbellSplitSquat => 80,
-            LungeExerciseName::UnknownVariant(value) => value,
+            LungeExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -20699,7 +20862,7 @@ impl fmt::Display for LungeExerciseName {
             LungeExerciseName::WideGripOverheadBarbellSplitSquat => {
                 write!(f, "wide_grip_overhead_barbell_split_squat")
             }
-            LungeExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            LungeExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -20787,7 +20950,7 @@ impl convert::From<u16> for LungeExerciseName {
             78 => LungeExerciseName::WalkingLunge,
             79 => LungeExerciseName::WeightedWalkingLunge,
             80 => LungeExerciseName::WideGripOverheadBarbellSplitSquat,
-            _ => LungeExerciseName::UnknownVariant(value),
+            _ => LungeExerciseName::Value(value),
         }
     }
 }
@@ -20801,7 +20964,10 @@ impl Serialize for LungeExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            LungeExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -20827,7 +20993,7 @@ pub enum OlympicLiftExerciseName {
     SingleArmKettlebellSnatch,
     SplitJerk,
     SquatCleanAndJerk,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl OlympicLiftExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -20879,7 +21045,7 @@ impl OlympicLiftExerciseName {
             OlympicLiftExerciseName::SingleArmKettlebellSnatch => 18,
             OlympicLiftExerciseName::SplitJerk => 19,
             OlympicLiftExerciseName::SquatCleanAndJerk => 20,
-            OlympicLiftExerciseName::UnknownVariant(value) => value,
+            OlympicLiftExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -20918,9 +21084,7 @@ impl fmt::Display for OlympicLiftExerciseName {
             }
             OlympicLiftExerciseName::SplitJerk => write!(f, "split_jerk"),
             OlympicLiftExerciseName::SquatCleanAndJerk => write!(f, "squat_clean_and_jerk"),
-            OlympicLiftExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            OlympicLiftExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -20948,7 +21112,7 @@ impl convert::From<u16> for OlympicLiftExerciseName {
             18 => OlympicLiftExerciseName::SingleArmKettlebellSnatch,
             19 => OlympicLiftExerciseName::SplitJerk,
             20 => OlympicLiftExerciseName::SquatCleanAndJerk,
-            _ => OlympicLiftExerciseName::UnknownVariant(value),
+            _ => OlympicLiftExerciseName::Value(value),
         }
     }
 }
@@ -20962,7 +21126,10 @@ impl Serialize for OlympicLiftExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            OlympicLiftExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -21102,7 +21269,7 @@ pub enum PlankExerciseName {
     PlankWithArmVariations,
     PlankWithLegLift,
     ReversePlankWithLegPull,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl PlankExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -21382,7 +21549,7 @@ impl PlankExerciseName {
             PlankExerciseName::PlankWithArmVariations => 132,
             PlankExerciseName::PlankWithLegLift => 133,
             PlankExerciseName::ReversePlankWithLegPull => 134,
-            PlankExerciseName::UnknownVariant(value) => value,
+            PlankExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -21652,7 +21819,7 @@ impl fmt::Display for PlankExerciseName {
             PlankExerciseName::PlankWithArmVariations => write!(f, "plank_with_arm_variations"),
             PlankExerciseName::PlankWithLegLift => write!(f, "plank_with_leg_lift"),
             PlankExerciseName::ReversePlankWithLegPull => write!(f, "reverse_plank_with_leg_pull"),
-            PlankExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            PlankExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -21794,7 +21961,7 @@ impl convert::From<u16> for PlankExerciseName {
             132 => PlankExerciseName::PlankWithArmVariations,
             133 => PlankExerciseName::PlankWithLegLift,
             134 => PlankExerciseName::ReversePlankWithLegPull,
-            _ => PlankExerciseName::UnknownVariant(value),
+            _ => PlankExerciseName::Value(value),
         }
     }
 }
@@ -21808,7 +21975,10 @@ impl Serialize for PlankExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            PlankExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -21846,7 +22016,7 @@ pub enum PlyoExerciseName {
     WeightedSquatJumpOntoBox,
     SquatJumpsInAndOut,
     WeightedSquatJumpsInAndOut,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl PlyoExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -21922,7 +22092,7 @@ impl PlyoExerciseName {
             PlyoExerciseName::WeightedSquatJumpOntoBox => 30,
             PlyoExerciseName::SquatJumpsInAndOut => 31,
             PlyoExerciseName::WeightedSquatJumpsInAndOut => 32,
-            PlyoExerciseName::UnknownVariant(value) => value,
+            PlyoExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -21983,7 +22153,7 @@ impl fmt::Display for PlyoExerciseName {
             PlyoExerciseName::WeightedSquatJumpsInAndOut => {
                 write!(f, "weighted_squat_jumps_in_and_out")
             }
-            PlyoExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            PlyoExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -22023,7 +22193,7 @@ impl convert::From<u16> for PlyoExerciseName {
             30 => PlyoExerciseName::WeightedSquatJumpOntoBox,
             31 => PlyoExerciseName::SquatJumpsInAndOut,
             32 => PlyoExerciseName::WeightedSquatJumpsInAndOut,
-            _ => PlyoExerciseName::UnknownVariant(value),
+            _ => PlyoExerciseName::Value(value),
         }
     }
 }
@@ -22037,7 +22207,10 @@ impl Serialize for PlyoExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            PlyoExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -22081,7 +22254,7 @@ pub enum PullUpExerciseName {
     SuspendedChinUp,
     WeightedSuspendedChinUp,
     PullUp,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl PullUpExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -22169,7 +22342,7 @@ impl PullUpExerciseName {
             PullUpExerciseName::SuspendedChinUp => 36,
             PullUpExerciseName::WeightedSuspendedChinUp => 37,
             PullUpExerciseName::PullUp => 38,
-            PullUpExerciseName::UnknownVariant(value) => value,
+            PullUpExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -22220,7 +22393,7 @@ impl fmt::Display for PullUpExerciseName {
             PullUpExerciseName::SuspendedChinUp => write!(f, "suspended_chin_up"),
             PullUpExerciseName::WeightedSuspendedChinUp => write!(f, "weighted_suspended_chin_up"),
             PullUpExerciseName::PullUp => write!(f, "pull_up"),
-            PullUpExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            PullUpExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -22266,7 +22439,7 @@ impl convert::From<u16> for PullUpExerciseName {
             36 => PullUpExerciseName::SuspendedChinUp,
             37 => PullUpExerciseName::WeightedSuspendedChinUp,
             38 => PullUpExerciseName::PullUp,
-            _ => PullUpExerciseName::UnknownVariant(value),
+            _ => PullUpExerciseName::Value(value),
         }
     }
 }
@@ -22280,7 +22453,10 @@ impl Serialize for PullUpExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            PullUpExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -22364,7 +22540,7 @@ pub enum PushUpExerciseName {
     WeightedRingPushUp,
     PushUp,
     PilatesPushup,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl PushUpExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -22532,7 +22708,7 @@ impl PushUpExerciseName {
             PushUpExerciseName::WeightedRingPushUp => 76,
             PushUpExerciseName::PushUp => 77,
             PushUpExerciseName::PilatesPushup => 78,
-            PushUpExerciseName::UnknownVariant(value) => value,
+            PushUpExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -22677,7 +22853,7 @@ impl fmt::Display for PushUpExerciseName {
             PushUpExerciseName::WeightedRingPushUp => write!(f, "weighted_ring_push_up"),
             PushUpExerciseName::PushUp => write!(f, "push_up"),
             PushUpExerciseName::PilatesPushup => write!(f, "pilates_pushup"),
-            PushUpExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            PushUpExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -22763,7 +22939,7 @@ impl convert::From<u16> for PushUpExerciseName {
             76 => PushUpExerciseName::WeightedRingPushUp,
             77 => PushUpExerciseName::PushUp,
             78 => PushUpExerciseName::PilatesPushup,
-            _ => PushUpExerciseName::UnknownVariant(value),
+            _ => PushUpExerciseName::Value(value),
         }
     }
 }
@@ -22777,7 +22953,10 @@ impl Serialize for PushUpExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            PushUpExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -22816,7 +22995,7 @@ pub enum RowExerciseName {
     UnderhandGripCableRow,
     VGripCableRow,
     WideGripSeatedCableRow,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl RowExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -22894,7 +23073,7 @@ impl RowExerciseName {
             RowExerciseName::UnderhandGripCableRow => 31,
             RowExerciseName::VGripCableRow => 32,
             RowExerciseName::WideGripSeatedCableRow => 33,
-            RowExerciseName::UnknownVariant(value) => value,
+            RowExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -22964,7 +23143,7 @@ impl fmt::Display for RowExerciseName {
             RowExerciseName::UnderhandGripCableRow => write!(f, "underhand_grip_cable_row"),
             RowExerciseName::VGripCableRow => write!(f, "v_grip_cable_row"),
             RowExerciseName::WideGripSeatedCableRow => write!(f, "wide_grip_seated_cable_row"),
-            RowExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            RowExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -23005,7 +23184,7 @@ impl convert::From<u16> for RowExerciseName {
             31 => RowExerciseName::UnderhandGripCableRow,
             32 => RowExerciseName::VGripCableRow,
             33 => RowExerciseName::WideGripSeatedCableRow,
-            _ => RowExerciseName::UnknownVariant(value),
+            _ => RowExerciseName::Value(value),
         }
     }
 }
@@ -23019,7 +23198,10 @@ impl Serialize for RowExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            RowExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -23048,7 +23230,7 @@ pub enum ShoulderPressExerciseName {
     SplitStanceHammerCurlToPress,
     SwissBallDumbbellShoulderPress,
     WeightPlateFrontRaise,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl ShoulderPressExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -23106,7 +23288,7 @@ impl ShoulderPressExerciseName {
             ShoulderPressExerciseName::SplitStanceHammerCurlToPress => 21,
             ShoulderPressExerciseName::SwissBallDumbbellShoulderPress => 22,
             ShoulderPressExerciseName::WeightPlateFrontRaise => 23,
-            ShoulderPressExerciseName::UnknownVariant(value) => value,
+            ShoulderPressExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -23174,9 +23356,7 @@ impl fmt::Display for ShoulderPressExerciseName {
             ShoulderPressExerciseName::WeightPlateFrontRaise => {
                 write!(f, "weight_plate_front_raise")
             }
-            ShoulderPressExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            ShoulderPressExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -23207,7 +23387,7 @@ impl convert::From<u16> for ShoulderPressExerciseName {
             21 => ShoulderPressExerciseName::SplitStanceHammerCurlToPress,
             22 => ShoulderPressExerciseName::SwissBallDumbbellShoulderPress,
             23 => ShoulderPressExerciseName::WeightPlateFrontRaise,
-            _ => ShoulderPressExerciseName::UnknownVariant(value),
+            _ => ShoulderPressExerciseName::Value(value),
         }
     }
 }
@@ -23221,7 +23401,10 @@ impl Serialize for ShoulderPressExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            ShoulderPressExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -23259,7 +23442,7 @@ pub enum ShoulderStabilityExerciseName {
     WeightedSwissBallWRaise,
     SwissBallYRaise,
     WeightedSwissBallYRaise,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl ShoulderStabilityExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -23335,7 +23518,7 @@ impl ShoulderStabilityExerciseName {
             ShoulderStabilityExerciseName::WeightedSwissBallWRaise => 30,
             ShoulderStabilityExerciseName::SwissBallYRaise => 31,
             ShoulderStabilityExerciseName::WeightedSwissBallYRaise => 32,
-            ShoulderStabilityExerciseName::UnknownVariant(value) => value,
+            ShoulderStabilityExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -23418,9 +23601,7 @@ impl fmt::Display for ShoulderStabilityExerciseName {
             ShoulderStabilityExerciseName::WeightedSwissBallYRaise => {
                 write!(f, "weighted_swiss_ball_y_raise")
             }
-            ShoulderStabilityExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            ShoulderStabilityExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -23460,7 +23641,7 @@ impl convert::From<u16> for ShoulderStabilityExerciseName {
             30 => ShoulderStabilityExerciseName::WeightedSwissBallWRaise,
             31 => ShoulderStabilityExerciseName::SwissBallYRaise,
             32 => ShoulderStabilityExerciseName::WeightedSwissBallYRaise,
-            _ => ShoulderStabilityExerciseName::UnknownVariant(value),
+            _ => ShoulderStabilityExerciseName::Value(value),
         }
     }
 }
@@ -23474,7 +23655,10 @@ impl Serialize for ShoulderStabilityExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            ShoulderStabilityExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -23496,7 +23680,7 @@ pub enum ShrugExerciseName {
     SerratusShrug,
     WeightedSerratusShrug,
     WideGripJumpShrug,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl ShrugExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -23540,7 +23724,7 @@ impl ShrugExerciseName {
             ShrugExerciseName::SerratusShrug => 14,
             ShrugExerciseName::WeightedSerratusShrug => 15,
             ShrugExerciseName::WideGripJumpShrug => 16,
-            ShrugExerciseName::UnknownVariant(value) => value,
+            ShrugExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -23571,7 +23755,7 @@ impl fmt::Display for ShrugExerciseName {
             ShrugExerciseName::SerratusShrug => write!(f, "serratus_shrug"),
             ShrugExerciseName::WeightedSerratusShrug => write!(f, "weighted_serratus_shrug"),
             ShrugExerciseName::WideGripJumpShrug => write!(f, "wide_grip_jump_shrug"),
-            ShrugExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            ShrugExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -23595,7 +23779,7 @@ impl convert::From<u16> for ShrugExerciseName {
             14 => ShrugExerciseName::SerratusShrug,
             15 => ShrugExerciseName::WeightedSerratusShrug,
             16 => ShrugExerciseName::WideGripJumpShrug,
-            _ => ShrugExerciseName::UnknownVariant(value),
+            _ => ShrugExerciseName::Value(value),
         }
     }
 }
@@ -23609,7 +23793,10 @@ impl Serialize for ShrugExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            ShrugExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -23652,7 +23839,7 @@ pub enum SitUpExerciseName {
     XAbs,
     WeightedXAbs,
     SitUp,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl SitUpExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -23738,7 +23925,7 @@ impl SitUpExerciseName {
             SitUpExerciseName::XAbs => 35,
             SitUpExerciseName::WeightedXAbs => 36,
             SitUpExerciseName::SitUp => 37,
-            SitUpExerciseName::UnknownVariant(value) => value,
+            SitUpExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -23800,7 +23987,7 @@ impl fmt::Display for SitUpExerciseName {
             SitUpExerciseName::XAbs => write!(f, "x_abs"),
             SitUpExerciseName::WeightedXAbs => write!(f, "weighted_x_abs"),
             SitUpExerciseName::SitUp => write!(f, "sit_up"),
-            SitUpExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SitUpExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -23845,7 +24032,7 @@ impl convert::From<u16> for SitUpExerciseName {
             35 => SitUpExerciseName::XAbs,
             36 => SitUpExerciseName::WeightedXAbs,
             37 => SitUpExerciseName::SitUp,
-            _ => SitUpExerciseName::UnknownVariant(value),
+            _ => SitUpExerciseName::Value(value),
         }
     }
 }
@@ -23859,7 +24046,10 @@ impl Serialize for SitUpExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SitUpExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -23957,7 +24147,7 @@ pub enum SquatExerciseName {
     SquatJumpsInNOut,
     PilatesPlieSquatsParallelTurnedOutFlatAndHeels,
     ReleveStraightLegAndKneeBentWithOneLegVariation,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl SquatExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -24151,7 +24341,7 @@ impl SquatExerciseName {
             SquatExerciseName::SquatJumpsInNOut => 89,
             SquatExerciseName::PilatesPlieSquatsParallelTurnedOutFlatAndHeels => 90,
             SquatExerciseName::ReleveStraightLegAndKneeBentWithOneLegVariation => 91,
-            SquatExerciseName::UnknownVariant(value) => value,
+            SquatExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -24290,7 +24480,7 @@ impl fmt::Display for SquatExerciseName {
                 f,
                 "releve_straight_leg_and_knee_bent_with_one_leg_variation"
             ),
-            SquatExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            SquatExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -24389,7 +24579,7 @@ impl convert::From<u16> for SquatExerciseName {
             89 => SquatExerciseName::SquatJumpsInNOut,
             90 => SquatExerciseName::PilatesPlieSquatsParallelTurnedOutFlatAndHeels,
             91 => SquatExerciseName::ReleveStraightLegAndKneeBentWithOneLegVariation,
-            _ => SquatExerciseName::UnknownVariant(value),
+            _ => SquatExerciseName::Value(value),
         }
     }
 }
@@ -24403,7 +24593,10 @@ impl Serialize for SquatExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            SquatExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -24421,7 +24614,7 @@ pub enum TotalBodyExerciseName {
     WeightedSquatPlankPushUp,
     StandingTRotationBalance,
     WeightedStandingTRotationBalance,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl TotalBodyExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -24457,7 +24650,7 @@ impl TotalBodyExerciseName {
             TotalBodyExerciseName::WeightedSquatPlankPushUp => 10,
             TotalBodyExerciseName::StandingTRotationBalance => 11,
             TotalBodyExerciseName::WeightedStandingTRotationBalance => 12,
-            TotalBodyExerciseName::UnknownVariant(value) => value,
+            TotalBodyExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -24486,7 +24679,7 @@ impl fmt::Display for TotalBodyExerciseName {
             TotalBodyExerciseName::WeightedStandingTRotationBalance => {
                 write!(f, "weighted_standing_t_rotation_balance")
             }
-            TotalBodyExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            TotalBodyExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -24506,7 +24699,7 @@ impl convert::From<u16> for TotalBodyExerciseName {
             10 => TotalBodyExerciseName::WeightedSquatPlankPushUp,
             11 => TotalBodyExerciseName::StandingTRotationBalance,
             12 => TotalBodyExerciseName::WeightedStandingTRotationBalance,
-            _ => TotalBodyExerciseName::UnknownVariant(value),
+            _ => TotalBodyExerciseName::Value(value),
         }
     }
 }
@@ -24520,7 +24713,10 @@ impl Serialize for TotalBodyExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            TotalBodyExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -24566,7 +24762,7 @@ pub enum TricepsExtensionExerciseName {
     TricepsExtensionOnFloor,
     TricepsPressdown,
     WeightedDip,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl TricepsExtensionExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -24658,7 +24854,7 @@ impl TricepsExtensionExerciseName {
             TricepsExtensionExerciseName::TricepsExtensionOnFloor => 38,
             TricepsExtensionExerciseName::TricepsPressdown => 39,
             TricepsExtensionExerciseName::WeightedDip => 40,
-            TricepsExtensionExerciseName::UnknownVariant(value) => value,
+            TricepsExtensionExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -24763,9 +24959,7 @@ impl fmt::Display for TricepsExtensionExerciseName {
             }
             TricepsExtensionExerciseName::TricepsPressdown => write!(f, "triceps_pressdown"),
             TricepsExtensionExerciseName::WeightedDip => write!(f, "weighted_dip"),
-            TricepsExtensionExerciseName::UnknownVariant(value) => {
-                write!(f, "unknown_variant_{}", *value)
-            }
+            TricepsExtensionExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -24813,7 +25007,7 @@ impl convert::From<u16> for TricepsExtensionExerciseName {
             38 => TricepsExtensionExerciseName::TricepsExtensionOnFloor,
             39 => TricepsExtensionExerciseName::TricepsPressdown,
             40 => TricepsExtensionExerciseName::WeightedDip,
-            _ => TricepsExtensionExerciseName::UnknownVariant(value),
+            _ => TricepsExtensionExerciseName::Value(value),
         }
     }
 }
@@ -24827,7 +25021,10 @@ impl Serialize for TricepsExtensionExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            TricepsExtensionExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -24864,7 +25061,7 @@ pub enum WarmUpExerciseName {
     WalkingLegCradles,
     Walkout,
     WalkoutFromPushUpPosition,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl WarmUpExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -24936,7 +25133,7 @@ impl WarmUpExerciseName {
             WarmUpExerciseName::WalkingLegCradles => 28,
             WarmUpExerciseName::Walkout => 29,
             WarmUpExerciseName::WalkoutFromPushUpPosition => 30,
-            WarmUpExerciseName::UnknownVariant(value) => value,
+            WarmUpExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -24989,7 +25186,7 @@ impl fmt::Display for WarmUpExerciseName {
             WarmUpExerciseName::WalkoutFromPushUpPosition => {
                 write!(f, "walkout_from_push_up_position")
             }
-            WarmUpExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            WarmUpExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -25027,7 +25224,7 @@ impl convert::From<u16> for WarmUpExerciseName {
             28 => WarmUpExerciseName::WalkingLegCradles,
             29 => WarmUpExerciseName::Walkout,
             30 => WarmUpExerciseName::WalkoutFromPushUpPosition,
-            _ => WarmUpExerciseName::UnknownVariant(value),
+            _ => WarmUpExerciseName::Value(value),
         }
     }
 }
@@ -25041,7 +25238,10 @@ impl Serialize for WarmUpExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            WarmUpExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -25050,7 +25250,7 @@ pub enum RunExerciseName {
     Walk,
     Jog,
     Sprint,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl RunExerciseName {
     pub fn is_named_variant(value: i64) -> bool {
@@ -25068,7 +25268,7 @@ impl RunExerciseName {
             RunExerciseName::Walk => 1,
             RunExerciseName::Jog => 2,
             RunExerciseName::Sprint => 3,
-            RunExerciseName::UnknownVariant(value) => value,
+            RunExerciseName::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -25082,7 +25282,7 @@ impl fmt::Display for RunExerciseName {
             RunExerciseName::Walk => write!(f, "walk"),
             RunExerciseName::Jog => write!(f, "jog"),
             RunExerciseName::Sprint => write!(f, "sprint"),
-            RunExerciseName::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            RunExerciseName::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -25093,7 +25293,7 @@ impl convert::From<u16> for RunExerciseName {
             1 => RunExerciseName::Walk,
             2 => RunExerciseName::Jog,
             3 => RunExerciseName::Sprint,
-            _ => RunExerciseName::UnknownVariant(value),
+            _ => RunExerciseName::Value(value),
         }
     }
 }
@@ -25107,7 +25307,10 @@ impl Serialize for RunExerciseName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            RunExerciseName::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -25407,7 +25610,7 @@ impl Serialize for DiveBacklightMode {
 pub enum FaveroProduct {
     AssiomaUno,
     AssiomaDuo,
-    UnknownVariant(u16),
+    Value(u16),
 }
 impl FaveroProduct {
     pub fn is_named_variant(value: i64) -> bool {
@@ -25421,7 +25624,7 @@ impl FaveroProduct {
         match self {
             FaveroProduct::AssiomaUno => 10,
             FaveroProduct::AssiomaDuo => 12,
-            FaveroProduct::UnknownVariant(value) => value,
+            FaveroProduct::Value(value) => value,
         }
     }
     pub fn as_i64(self) -> i64 {
@@ -25433,7 +25636,7 @@ impl fmt::Display for FaveroProduct {
         match &self {
             FaveroProduct::AssiomaUno => write!(f, "assioma_uno"),
             FaveroProduct::AssiomaDuo => write!(f, "assioma_duo"),
-            FaveroProduct::UnknownVariant(value) => write!(f, "unknown_variant_{}", *value),
+            FaveroProduct::Value(value) => write!(f, "{}", value),
         }
     }
 }
@@ -25442,7 +25645,7 @@ impl convert::From<u16> for FaveroProduct {
         match value {
             10 => FaveroProduct::AssiomaUno,
             12 => FaveroProduct::AssiomaDuo,
-            _ => FaveroProduct::UnknownVariant(value),
+            _ => FaveroProduct::Value(value),
         }
     }
 }
@@ -25456,7 +25659,10 @@ impl Serialize for FaveroProduct {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match &self {
+            FaveroProduct::Value(value) => serializer.serialize_u16(*value),
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]

--- a/generate-fit-profile/src/decode.rs
+++ b/generate-fit-profile/src/decode.rs
@@ -270,14 +270,33 @@ impl MessageFieldDefinition {
         writeln!(out, "else {{")?;
         writeln!(out, "  value")?;
         writeln!(out, "}};")?;
+
         // generate field
-        writeln!(
-            out,
-            "data_field_with_info({0}, \"{1}\", FieldDataType::{2}, scale, offset, units, value, options)",
-            self.def_number(),
-            self.name(),
-            self.field_type()
-        )?;
+        if let Some(parent) = self.parent_field() {
+            writeln!(
+                out,
+                "let name = if options.contains(&DecodeOption::UseGenericSubFieldName) {{"
+            )?;
+            writeln!(out, "\"{}\"", parent.name())?;
+            writeln!(out, "}}")?;
+            writeln!(out, "else {{")?;
+            writeln!(out, "\"{}\"", self.name())?;
+            writeln!(out, "}};")?;
+            writeln!(
+                out,
+                "data_field_with_info({}, name, FieldDataType::{}, scale, offset, units, value, options)",
+                self.def_number(),
+                self.field_type()
+            )?;
+        } else {
+            writeln!(
+                out,
+                "data_field_with_info({0}, \"{1}\", FieldDataType::{2}, scale, offset, units, value, options)",
+                self.def_number(),
+                self.name(),
+                self.field_type()
+            )?;
+        }
         //
         writeln!(out, "}}")?;
         Ok(())

--- a/generate-fit-profile/src/field_types.rs
+++ b/generate-fit-profile/src/field_types.rs
@@ -19,7 +19,12 @@ impl FieldTypeDefintion {
         for variant in self.variant_map().values() {
             variant.write_variant_line(out)?;
         }
-        writeln!(out, "UnknownVariant({}),", self.base_type())?;
+        writeln!(
+            out,
+            "{}({}),",
+            self.other_value_field_name(),
+            self.base_type()
+        )?;
         writeln!(out, "}}")?;
 
         self.generate_impl(out)
@@ -51,8 +56,9 @@ impl FieldTypeDefintion {
         }
         writeln!(
             out,
-            "{}::UnknownVariant(value) => value",
-            self.titlized_name()
+            "{}::{}(value) => value",
+            self.titlized_name(),
+            self.other_value_field_name(),
         )?;
         writeln!(out, "}}")?;
         writeln!(out, "}}")?;
@@ -78,11 +84,21 @@ impl FieldTypeDefintion {
                 variant.name()
             )?;
         }
-        writeln!(
-            out,
-            "{}::UnknownVariant(value) => write!(f, \"unknown_variant_{{}}\", *value)",
-            self.titlized_name()
-        )?;
+        if self.is_true_enum() {
+            writeln!(
+                out,
+                "{}::{}(value) => write!(f, \"unknown_variant_{{}}\", *value)",
+                self.titlized_name(),
+                self.other_value_field_name(),
+            )?;
+        } else {
+            writeln!(
+                out,
+                "{}::{}(value) => write!(f, \"{{}}\", value),",
+                self.titlized_name(),
+                self.other_value_field_name(),
+            )?;
+        }
         writeln!(out, "}}")?;
         writeln!(out, "}}")?;
         writeln!(out, "}}")?;
@@ -104,7 +120,12 @@ impl FieldTypeDefintion {
                 variant.titlized_name()
             )?;
         }
-        writeln!(out, " _ => {}::UnknownVariant(value)", self.titlized_name())?;
+        writeln!(
+            out,
+            " _ => {}::{}(value)",
+            self.titlized_name(),
+            self.other_value_field_name()
+        )?;
         writeln!(out, "}}")?;
         writeln!(out, "}}")?;
         writeln!(out, "}}")?;


### PR DESCRIPTION
Implemented additional decode options

- [X] Numeric-ony enum value serialization
- [X] Improve default enum serialization to only "stringify" named members
- [x] Drop unknown messages
- [x] Drop unknown fields
- [x] Retain original field name when de-referencing subfields (e.g. return "product" still instead of "garmin_product")

Fixes #19 
Closes #20 