### PR TITLE
Value array handling

### DIFF
--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -595,22 +595,16 @@ fn data_field_value(
             _ => le_u8(input).map(|(i, v)| (i, Value::UInt8(v)))?, // Treat unexpected like Byte
         };
         bytes_consumed += base_type.size();
-        values.push(value);
+        if value.is_valid() {
+            values.push(value);
+        }
         input = i;
     }
-
-    // Return either a regular Value or an Array of them
-    let value = if values.len() == 1 {
-        values.swap_remove(0)
-    } else {
-        Value::Array(values)
-    };
-
-    // Only return "something" if it's in the valid range
-    if value.is_valid() {
-        Ok((input, Some(value)))
-    } else {
-        Ok((input, None))
+    // Return None if the values are invalid, a regular Value or an Array of them
+    match values.len(){
+        0 => Ok((input, None)),
+        1 => Ok((input, Some(values.swap_remove(0)))),
+        _ => Ok((input, Some(Value::Array(values))))
     }
 }
 


### PR DESCRIPTION
## Reason for this PR

I noticed that Hrv message values are not parsed.

### cause

Messages which contain a value array like the Hrv message type may contain valid and invalid values.
Due to the value validation code in [parser.rs:39-41](https://github.com/stadelmanma/fitparse-rs/blob/1a1ebae5bccc473a04e46bcffd61f89130443165/fitparser/src/de/parser.rs#L39C13-L41C89), those values would be dropped entirely.

## Change:

This change addresses this problem by only collecting valid values in the values vector.