### PR TITLE
Implement handling of invalid values in arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+## HEAD
+* Improve support for array handling in FIT files (mat-kie)
+
 ## v0.8.0
 * Bump packaged FIT SDK version to 21.141.00 (lingepumpe)
 * Implement developer field data parsing (lingepumpe)
-
 
 ## v0.7.0
 * Bump packaged FIT SDK version to 21.133.00 (robinkrahl)

--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn data_field_value_test_array_value() {
-        let data = [0x00, 0x01, 0x02, 0x03, 0xFF];
+        let data = [0x00, 0x01, 0x02, 0x03, 0xFF, 0x05];
 
         // parse off a valid byte
         let (rem, val) =
@@ -706,18 +706,24 @@ mod tests {
             ),
             None => panic!("No value returned."),
         }
-        assert_eq!(rem, &[0xFF]);
+        assert_eq!(rem, &[0xFF, 0x05]);
 
         // parse off an invalid byte
         let (rem, val) =
-            data_field_value(&data, FitBaseType::Uint8, Endianness::Native, 5).unwrap();
-        if val.is_some() {
-            panic!("None should be returned for invalid bytes.")
-        }
-        assert_eq!(rem, &[]);
-
-        if val.is_some() {
-            panic!("None should be returned for array with an invalid size.")
+            data_field_value(&data, FitBaseType::Uint8, Endianness::Native, 6).unwrap();
+        match val {
+            Some(v) => assert_eq!(
+                v,
+                Value::Array(vec![
+                    Value::UInt8(0x00),
+                    Value::UInt8(0x01),
+                    Value::UInt8(0x02),
+                    Value::UInt8(0x03),
+                    Value::Invalid,
+                    Value::UInt8(0x05),
+                ])
+            ),
+            None => panic!("No value returned."),
         }
         assert_eq!(rem, &[]);
     }

--- a/fitparser/src/lib.rs
+++ b/fitparser/src/lib.rs
@@ -201,6 +201,8 @@ pub enum Value {
     /// Array of Values, while this allows nested arrays and mixed types this is not possible
     /// in a properly formatted FIT file
     Array(Vec<Self>),
+    /// Placeholder for invalid values in output
+    Invalid,
 }
 
 impl fmt::Display for Value {
@@ -224,7 +226,8 @@ impl fmt::Display for Value {
             Value::Float32(val) => write!(f, "{}", val),
             Value::Float64(val) => write!(f, "{}", val),
             Value::String(val) => write!(f, "{}", val),
-            Value::Array(vals) => write!(f, "{:?}", vals), // printing arrays is hard
+            Value::Array(vals) => write!(f, "{:?}", vals), // printing arrays is hard,
+            Value::Invalid => write!(f, ""),
         }
     }
 }
@@ -257,6 +260,10 @@ impl convert::TryInto<f64> for Value {
             Value::Array(_) => {
                 Err(ErrorKind::ValueError(format!("cannot convert {} into an f64", self)).into())
             }
+            Value::Invalid => Err(ErrorKind::ValueError(format!(
+                "cannot convert an invalid value into an f64"
+            ))
+            .into()),
         }
     }
 }
@@ -293,6 +300,10 @@ impl convert::TryInto<i64> for Value {
             Value::Array(_) => {
                 Err(ErrorKind::ValueError(format!("cannot convert {} into an i64", self)).into())
             }
+            Value::Invalid => Err(ErrorKind::ValueError(format!(
+                "cannot convert an invalid value into an i64"
+            ))
+            .into()),
         }
     }
 }
@@ -329,6 +340,10 @@ impl convert::TryInto<i64> for &Value {
             Value::Array(_) => {
                 Err(ErrorKind::ValueError(format!("cannot convert {} into an i64", self)).into())
             }
+            Value::Invalid => Err(ErrorKind::ValueError(format!(
+                "cannot convert an invalid value into an i64"
+            ))
+            .into()),
         }
     }
 }


### PR DESCRIPTION
Retaining invalid values in arrays ensures we don't lose length or position information in the parsed data. Non-array invalid values are still stripped from the output. 
 
JSON rendition of a HRV message with invalid values:
```json
  {
    "kind": "hrv",
    "fields": {
      "time": {
        "value": [
          0.467,
          0.464,
          null,
          null,
          null
        ],
        "units": "s"
      }
    }
  }
```

Closes #45