### PR TITLE
Correct parsing of arrays and byte arrays

### DIFF
--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -567,7 +567,7 @@ fn data_field_value(
 ) -> IResult<&[u8], Option<Value>> {
     let mut input = input;
     let mut bytes_consumed = 0;
-    let mut values: Vec<Value> = Vec::new();
+    let mut values: Vec<Value> = Vec::with_capacity((size / base_type.size()) as _);
 
     while bytes_consumed < size {
         let (i, value) = match base_type {
@@ -616,6 +616,7 @@ fn data_field_value(
     let value = if values.len() == 1 {
         values.swap_remove(0)
     } else {
+        values.shrink_to_fit();
         Value::Array(values)
     };
 

--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -38,7 +38,7 @@ impl Value {
             Value::UInt64(val) => *val != 0xFFFF_FFFF_FFFF_FFFF,
             Value::UInt64z(val) => *val != 0x0,
             Value::Array(vals) => {
-                if let Some(first) = vals.first().map(|v| discriminant(v)) {
+                if let Some(first) = vals.first().map(discriminant) {
                     let mut same_type = true;
                     let mut any_valid = false;
                     for v in vals {

--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -582,14 +582,11 @@ fn data_field_value(
                 // consume the field as defined by its size and then locate the first NUL byte
                 // and ignore everything after it when converting to a string
                 let (input, field_value) = take(size as usize)(input)?;
-                let mut value = Vec::new();
-                for char in field_value {
-                    if *char == 0u8 {
-                        break;
-                    }
-                    value.push(*char);
-                }
-                if let Ok(value) = String::from_utf8(value) {
+                let field_value = &field_value[0..field_value
+                    .iter()
+                    .position(|v| *v == 0u8)
+                    .unwrap_or(field_value.len())];
+                if let Ok(value) = String::from_utf8(field_value.to_owned()) {
                     return Ok((input, Some(Value::String(value))));
                 } else {
                     return Ok((input, None));

--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -604,7 +604,7 @@ fn data_field_value(
             _ => le_u8(input).map(|(i, v)| (i, Value::UInt8(v)))?, // Treat unexpected like Byte
         };
         bytes_consumed += base_type.size();
-        if value.is_valid() {
+        if matches!(base_type, FitBaseType::Byte) || value.is_valid() {
             values.push(value);
         } else {
             values.push(Value::Invalid)
@@ -734,6 +734,27 @@ mod tests {
             None => panic!("No value returned."),
         }
         assert_eq!(rem, &[]);
+    }
+
+    #[test]
+    fn data_field_value_test_byte_array_value() {
+        let data = [0xFF, 0x01, 0xFF, 0x03, 0xFF, 0x05];
+
+        // parse off a valid byte array containing 0xFF bytes
+        let (rem, val) = data_field_value(&data, FitBaseType::Byte, Endianness::Native, 4).unwrap();
+        match val {
+            Some(v) => assert_eq!(
+                v,
+                Value::Array(vec![
+                    Value::Byte(0xFF),
+                    Value::Byte(0x01),
+                    Value::Byte(0xFF),
+                    Value::Byte(0x03),
+                ])
+            ),
+            None => panic!("No value returned."),
+        }
+        assert_eq!(rem, &[0xFF, 0x05]);
     }
 
     #[test]

--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -597,7 +597,7 @@ fn data_field_value(
             FitBaseType::Uint8z => le_u8(input).map(|(i, v)| (i, Value::UInt8z(v)))?,
             FitBaseType::Uint16z => u16(byte_order)(input).map(|(i, v)| (i, Value::UInt16z(v)))?,
             FitBaseType::Uint32z => u32(byte_order)(input).map(|(i, v)| (i, Value::UInt32z(v)))?,
-            FitBaseType::Byte => le_u8(input).map(|(i, v)| (i, Value::UInt8(v)))?,
+            FitBaseType::Byte => le_u8(input).map(|(i, v)| (i, Value::Byte(v)))?,
             FitBaseType::Sint64 => i64(byte_order)(input).map(|(i, v)| (i, Value::SInt64(v)))?,
             FitBaseType::Uint64 => u64(byte_order)(input).map(|(i, v)| (i, Value::UInt64(v)))?,
             FitBaseType::Uint64z => u64(byte_order)(input).map(|(i, v)| (i, Value::UInt64z(v)))?,

--- a/fitparser/src/de/parser.rs
+++ b/fitparser/src/de/parser.rs
@@ -812,6 +812,11 @@ mod tests {
             val.is_valid(),
             "This Value array should be valid since it contains a valid value"
         );
+        let val = Value::Array(vec![Value::Invalid, Value::UInt8(42u8)]);
+        assert!(
+            val.is_valid(),
+            "This Value array should be valid since it contains a valid value"
+        );
         let val = Value::Array(vec![Value::UInt8(0x00), Value::UInt8(42u8)]);
         assert!(
             val.is_valid(),

--- a/fitparser/src/lib.rs
+++ b/fitparser/src/lib.rs
@@ -260,9 +260,9 @@ impl convert::TryInto<f64> for Value {
             Value::Array(_) => {
                 Err(ErrorKind::ValueError(format!("cannot convert {} into an f64", self)).into())
             }
-            Value::Invalid => Err(ErrorKind::ValueError(format!(
-                "cannot convert an invalid value into an f64"
-            ))
+            Value::Invalid => Err(ErrorKind::ValueError(
+                "cannot convert an invalid value into an f64".to_string(),
+            )
             .into()),
         }
     }
@@ -300,9 +300,9 @@ impl convert::TryInto<i64> for Value {
             Value::Array(_) => {
                 Err(ErrorKind::ValueError(format!("cannot convert {} into an i64", self)).into())
             }
-            Value::Invalid => Err(ErrorKind::ValueError(format!(
-                "cannot convert an invalid value into an i64"
-            ))
+            Value::Invalid => Err(ErrorKind::ValueError(
+                "cannot convert an invalid value into an i64".to_string(),
+            )
             .into()),
         }
     }
@@ -340,9 +340,9 @@ impl convert::TryInto<i64> for &Value {
             Value::Array(_) => {
                 Err(ErrorKind::ValueError(format!("cannot convert {} into an i64", self)).into())
             }
-            Value::Invalid => Err(ErrorKind::ValueError(format!(
-                "cannot convert an invalid value into an i64"
-            ))
+            Value::Invalid => Err(ErrorKind::ValueError(
+                "cannot convert an invalid value into an i64".to_string(),
+            )
             .into()),
         }
     }


### PR DESCRIPTION
Related to #46 

## Behavioral Changes
- If a single byte inside a Byte array is valid, all bytes are considered valid
- ~~guard against multiple discriminants in value arrays~~

## Changes:
- Fix return type for Value::Byte in data_field_value
- avoid vector  re allocations during parsing
- ~~add checks to ensure a Value::Array is only valid if all entries share the same discriminant (or are set to Invalid)~~
- add test cases for Byte array parsing
- add tests for is_valid check